### PR TITLE
ARIA-6 Add tox.ini and .travis files for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,28 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 sudo: false
 language: python
 python:
-    - "2.7"
+  - "2.7"
 env:
-    - TOX_ENV=pylint_package
-    - TOX_ENV=pylint_tests
-    - TOX_ENV=py26
-    - TOX_ENV=py27
+- TOX_ENV=pylint_code
+- TOX_ENV=pylint_tests
+- TOX_ENV=py27
+- TOX_ENV=py26
 install:
-    - pip install tox==1.6.1
+  - pip install --upgrade pip
+  - pip install tox
 script:
-    - tox -e $TOX_ENV
-
+  - pip --version
+  - tox --version
+  - tox -e $TOX_ENV

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,17 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 PyYAML==3.10
-networkx==1.11
+networkx==1.9
 requests==2.7.0
 retrying==1.3.3
 blinker==1.4

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if (sys.version_info[0], sys.version_info[1]) not in _PYTHON_SUPPORTED_VERSIONS:
         '{0} Package support Python version 2.6 & 2.7 Only'.format(
             _PACKAGE_NAME))
 
-version = '0.0.1'
+version = '0.1.0'
 execfile(os.path.join('.', _PACKAGE_NAME, 'VERSION.py'))
 
 
@@ -45,10 +45,10 @@ setup(
     name=_PACKAGE_NAME,
     version=version,
     author='aria-core',
-    author_email='cosmo-admin@gigaspaces.com',
+    author_email='dev@ariatosca.incubator.apache.org',
     packages=find_packages(exclude=('*tests*',)),
     license='LICENSE',
-    description='Aria Project',
+    description='ARIA Project',
     zip_safe=False,
     install_requires=install_requires,
     entry_points={

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,17 @@
-mock>=1.0.1
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 testtools
-tox==1.6.1
+mock==1.0.1
 pylint==1.5.5
 pytest==3.0.2
 pytest-cov==2.3.1

--- a/tests/storage/test_models.py
+++ b/tests/storage/test_models.py
@@ -47,7 +47,7 @@ def test_base_model_members():
 
     test_model = TestModel1(test_field='test_field_value', id='test_id')
 
-    assert repr(test_model) == "TestModel(fields=['id', 'test_field'])"
+    assert repr(test_model) == "TestModel1(fields=['id', 'test_field'])"
     expected = {'test_field': 'test_field_value', 'id': 'test_id'}
     assert json.loads(test_model.json) == expected
     assert test_model.fields_dict == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,40 @@
-# content of: tox.ini , put in same dir as setup.py
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 [tox]
-envlist=pylint_package,pylint_tests,py27
+envlist=py27,py26,pylint_code,pylint_tests
 
 [testenv]
-deps =-r{toxinidir}/tests/requirements.txt
+deps =
+    -rrequirements.txt
+    -rtests/requirements.txt
+basepython =
+  py26: python2.6
+  py27: python2.7
+  pylint_code: python2.7
+  pylint_tests: python2.7
 
 [testenv:py27]
-commands=py.test tests --cov-report term-missing --cov aria
+commands=pytest tests --cov-report term-missing --cov aria
 
-[testenv:pylint_package]
-commands=pylint aria --rcfile=.pylintrc --disable=cyclic-import,fixme
+[testenv:py26]
+commands=pytest tests --cov-report term-missing --cov aria
+
+[testenv:pylint_code]
+deps =
+    pylint
+commands=pylint aria --rcfile=aria/.pylintrc
 
 [testenv:pylint_tests]
-commands=pylint tests --rcfile=.pylintrc --disable=invalid-name,too-many-statements,too-few-public-methods,too-many-lines,too-many-public-methods,unused-argument,line-too-long,no-member,too-many-locals,duplicate-code,too-many-branches,too-many-arguments,fixme
+deps =
+    pylint
+commands=pylint tests --rcfile=tests/.pylintrc


### PR DESCRIPTION
The files actually existed but were out of date.
Both are now up to date. Tox will take care of installing both
code requirements and tests requirements before running the tests.

Additional changes:

 - several setup.py changes (set version to 0.1.0; updated email)

 - minor changes to tests' requirements (removed tox, froze mock)

 - fixed typo in "test_base_model_members" unit test

 - modified networkx dependency version to 1.9 (for py2.6 support)

 - added missing license header to requirements.txt files