### PR TITLE
ARIA-126 Add node states

### DIFF
--- a/aria/modeling/service_template.py
+++ b/aria/modeling/service_template.py
@@ -497,7 +497,7 @@ class NodeTemplateBase(TemplateModelMixin):
         node = models.Node(name=name,
                            type=self.type,
                            description=deepcopy_with_locators(self.description),
-                           state='',
+                           state=models.Node.INITIAL,
                            node_template=self)
         utils.instantiate_dict(node, node.properties, self.properties)
         utils.instantiate_dict(node, node.interfaces, self.interface_templates)

--- a/tests/mock/models.py
+++ b/tests/mock/models.py
@@ -121,7 +121,7 @@ def create_dependency_node(dependency_node_template, service):
         runtime_properties={'ip': '1.1.1.1'},
         version=None,
         node_template=dependency_node_template,
-        state='',
+        state=models.Node.INITIAL,
         scaling_groups=[],
         service=service
     )
@@ -136,7 +136,7 @@ def create_dependent_node(dependent_node_template, service):
         runtime_properties={},
         version=None,
         node_template=dependent_node_template,
-        state='',
+        state=models.Node.INITIAL,
         scaling_groups=[],
         service=service
     )

--- a/tests/modeling/test_mixins.py
+++ b/tests/modeling/test_mixins.py
@@ -127,7 +127,7 @@ def test_relationship_model_ordering(context):
         service=service,
         version=None,
         node_template=new_node_template,
-        state='',
+        state=modeling.models.Node.INITIAL,
         scaling_groups=[]
     )
 

--- a/tests/modeling/test_models.py
+++ b/tests/modeling/test_models.py
@@ -554,11 +554,11 @@ class TestNode(object):
             (False, 'name', {}, [], m_cls, 1),
             (False, m_cls, {}, [], 'state', m_cls),
 
-            (True, 'name', {}, [], 'state', 1),
-            (True, None, {}, [], 'state', 1),
-            (True, 'name', None, [], 'state', 1),
-            (True, 'name', {}, None, 'state', 1),
-            (True, 'name', {}, [], 'state', None),
+            (True, 'name', {}, [], 'initial', 1),
+            (True, None, {}, [], 'initial', 1),
+            (True, 'name', None, [], 'initial', 1),
+            (True, 'name', {}, None, 'initial', 1),
+            (True, 'name', {}, [], 'initial', None),
         ]
     )
     def test_node_model_creation(self, node_template_storage, is_valid, name, runtime_properties,
@@ -645,7 +645,7 @@ class TestNodeIP(object):
             node_template=node,
             type=storage.type.list()[0],
             runtime_properties={},
-            state='',
+            state='initial',
             service=storage.service.list()[0]
         )
         if ip:

--- a/tests/orchestrator/workflows/core/test_events.py
+++ b/tests/orchestrator/workflows/core/test_events.py
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from tests import mock, storage
+from aria.modeling.service_instance import NodeBase
+from aria.orchestrator.decorators import operation, workflow
+from aria.orchestrator.workflows.core import engine
+from aria.orchestrator.workflows.executor.thread import ThreadExecutor
+from aria.orchestrator.workflows import api
+
+global_test_dict = {}  # used to capture transitional node state changes
+
+
+@pytest.fixture
+def ctx(tmpdir):
+    context = mock.context.simple(str(tmpdir))
+    yield context
+    storage.release_sqlite_storage(context.model)
+
+# TODO another possible approach of writing these tests:
+# Don't create a ctx for every test.
+# Problem is, that if for every test we create a workflow that contains just one standard
+# lifecycle operation, then by the time we try to run the second test, the workflow failes since
+# the execution tries to go from 'terminated' to 'pending'.
+# And if we write a workflow that contains all the lifecycle operations, then first we need to
+# change the api of `mock.models.create_interface`, which a lot of other tests use, and second how
+# do we check all the state transition during the workflow execution in a convenient way.
+
+TYPE_URI_NAME = 'tosca.interfaces.node.lifecycle.Standard'
+SHORTHAND_NAME = 'Standard'
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_create(ctx):
+    node = run_operation_on_node(ctx, interface_name=TYPE_URI_NAME, op_name='create')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'create')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_configure(ctx):
+    node = run_operation_on_node(ctx, interface_name=TYPE_URI_NAME, op_name='configure')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'configure')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_start(ctx):
+    node = run_operation_on_node(ctx, interface_name=TYPE_URI_NAME, op_name='start')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'start')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_stop(ctx):
+    node = run_operation_on_node(ctx, interface_name=TYPE_URI_NAME, op_name='stop')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'stop')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_delete(ctx):
+    node = run_operation_on_node(ctx, interface_name=TYPE_URI_NAME, op_name='delete')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'delete')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_create_shorthand_name(ctx):
+    node = run_operation_on_node(ctx, interface_name=SHORTHAND_NAME, op_name='create')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'create')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_configure_shorthand_name(ctx):
+    node = run_operation_on_node(ctx, interface_name=SHORTHAND_NAME, op_name='configure')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'configure')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_start_shorthand_name(ctx):
+    node = run_operation_on_node(ctx, interface_name=SHORTHAND_NAME, op_name='start')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'start')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_stop_shorthand_name(ctx):
+    node = run_operation_on_node(ctx, interface_name=SHORTHAND_NAME, op_name='stop')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'stop')
+
+
+def test_node_state_changes_as_a_result_of_standard_lifecycle_delete_shorthand_name(ctx):
+    node = run_operation_on_node(ctx, interface_name=SHORTHAND_NAME, op_name='delete')
+    _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, 'delete')
+
+
+def test_node_state_doesnt_change_as_a_result_of_an_operation_that_is_not_standard_lifecycle1(ctx):
+    node = run_operation_on_node(ctx, interface_name='interface_name', op_name='op_name')
+    assert node.state == node.INITIAL
+
+
+def test_node_state_doesnt_change_as_a_result_of_an_operation_that_is_not_standard_lifecycle2(ctx):
+    node = run_operation_on_node(ctx, interface_name='interface_name', op_name='create')
+    assert node.state == node.INITIAL
+
+
+def run_operation_on_node(ctx, op_name, interface_name):
+    node = ctx.model.node.get_by_name(mock.models.DEPENDENCY_NODE_NAME)
+    interface = mock.models.create_interface(
+        service=node.service,
+        interface_name=interface_name,
+        operation_name=op_name,
+        operation_kwargs=dict(implementation='{name}.{func.__name__}'.format(name=__name__,
+                                                                             func=func)))
+    node.interfaces[interface.name] = interface
+
+    eng = engine.Engine(executor=ThreadExecutor(),
+                        workflow_context=ctx,
+                        tasks_graph=single_operation_workflow(ctx=ctx,  # pylint: disable=no-value-for-parameter
+                                                              node=node,
+                                                              interface_name=interface_name,
+                                                              op_name=op_name))
+    eng.execute()
+    return node
+
+
+def run_standard_lifecycle_operation_on_node(ctx, op_name):
+    return run_operation_on_node(ctx, interface_name='aria.interfaces.lifecycle.Standard',
+                                 op_name=op_name)
+
+
+def _assert_node_state_changed_as_a_result_of_standard_lifecycle_operation(node, op_name):
+    assert global_test_dict['transitional_state'] == NodeBase._op_to_state[op_name]['transitional']
+    assert node.state == NodeBase._op_to_state[op_name]['finished']
+
+
+@workflow
+def single_operation_workflow(graph, node, interface_name, op_name, **_):
+    graph.add_tasks(api.task.OperationTask.for_node(
+        node=node,
+        interface_name=interface_name,
+        operation_name=op_name))
+
+
+@operation
+def func(ctx):
+    global_test_dict['transitional_state'] = ctx.node.state


### PR DESCRIPTION
1. The states are described in section 3.3.1 of the TOSCA spec.

2. The state is changed if a standard lifecycle operation runs of the
node, as described in sections 5.7.4.1, 5.7.4.4.1, and 5.7.4.4.2 of the TOSCA spec.

3. We did not address the 'error' state yet.
This state is defined as part of the possible node states in the model, but currently no execution path leads to setting a node's state to 'error'.

4. No validation of state transiontions.
For example, we do not validate if a node goes from 'created'
to 'started' without going through the 'configured' state in between.