### PR TITLE
ARIA-133 Add status-related methods to the Execution, Task and Node models

### DIFF
--- a/aria/modeling/service_instance.py
+++ b/aria/modeling/service_instance.py
@@ -417,6 +417,10 @@ class NodeBase(InstanceModelMixin):
         except KeyError:
             return None
 
+    @property
+    def is_available(self):
+        return self.state not in [self.INITIAL, self.DELETED, self.ERROR]
+
     # region foreign_keys
 
     @declared_attr

--- a/aria/orchestrator/workflows/core/engine.py
+++ b/aria/orchestrator/workflows/core/engine.py
@@ -88,12 +88,12 @@ class Engine(logger.LoggerMixin):
     def _executable_tasks(self):
         now = datetime.utcnow()
         return (task for task in self._tasks_iter()
-                if task.status in models.Task.WAIT_STATES and
+                if task.is_waiting and
                 task.due_at <= now and
                 not self._task_has_dependencies(task))
 
     def _ended_tasks(self):
-        return (task for task in self._tasks_iter() if task.status in models.Task.END_STATES)
+        return (task for task in self._tasks_iter() if task.has_ended)
 
     def _task_has_dependencies(self, task):
         return len(self._execution_graph.pred.get(task.id, {})) > 0
@@ -105,7 +105,7 @@ class Engine(logger.LoggerMixin):
         for _, data in self._execution_graph.nodes_iter(data=True):
             task = data['task']
             if isinstance(task, engine_task.OperationTask):
-                if task.model_task.status not in models.Task.END_STATES:
+                if not task.model_task.has_ended:
                     self._workflow_context.model.task.refresh(task.model_task)
             yield task
 

--- a/aria/orchestrator/workflows/core/task.py
+++ b/aria/orchestrator/workflows/core/task.py
@@ -69,6 +69,14 @@ class StubTask(BaseTask):
         self.status = models.Task.PENDING
         self.due_at = datetime.utcnow()
 
+    @property
+    def has_ended(self):
+        return self.status in [models.Task.SUCCESS, models.Task.FAILED]
+
+    @property
+    def is_waiting(self):
+        return self.status in [models.Task.PENDING, models.Task.RETRYING]
+
 
 class StartWorkflowTask(StubTask):
     """


### PR DESCRIPTION
We are adding these methods so it will be easier to filter those models
from storage according to their status, and to not make use of the their
`status` constants outside of the models themselves.