### PR TITLE
ARIA-92 Automatic operation task configuration

### DIFF
--- a/aria/cli/dry.py
+++ b/aria/cli/dry.py
@@ -43,14 +43,19 @@ def convert_to_dry(service):
                 for oper in interface.operations.itervalues():
                     convert_operation_to_dry(oper)
 
+    for group in service.groups.itervalues():
+        for interface in group.interfaces.itervalues():
+            for oper in interface.operations.itervalues():
+                convert_operation_to_dry(oper)
+
 
 def convert_operation_to_dry(oper):
     """
     Converts a single :class:`Operation` to run dryly.
     """
 
-    plugin = oper.plugin_specification.name \
-        if oper.plugin_specification is not None else None
+    plugin = oper.plugin.name \
+        if oper.plugin is not None else None
     if oper.inputs is None:
         oper.inputs = OrderedDict()
     oper.inputs['_implementation'] = models.Parameter(name='_implementation',

--- a/aria/modeling/models.py
+++ b/aria/modeling/models.py
@@ -48,6 +48,7 @@ __all__ = (
     'InterfaceTemplate',
     'OperationTemplate',
     'ArtifactTemplate',
+    'PluginSpecification',
 
     # Service instance models
     'Service',
@@ -71,7 +72,6 @@ __all__ = (
     'Parameter',
     'Type',
     'Metadata',
-    'PluginSpecification',
 
     # Orchestration models
     'Execution',
@@ -129,6 +129,9 @@ class OperationTemplate(aria_declarative_base, service_template.OperationTemplat
 
 
 class ArtifactTemplate(aria_declarative_base, service_template.ArtifactTemplateBase):
+    pass
+
+class PluginSpecification(aria_declarative_base, service_template.PluginSpecificationBase):
     pass
 
 # endregion
@@ -211,10 +214,6 @@ class Type(aria_declarative_base, service_common.TypeBase):
 class Metadata(aria_declarative_base, service_common.MetadataBase):
     pass
 
-
-class PluginSpecification(aria_declarative_base, service_common.PluginSpecificationBase):
-    pass
-
 # endregion
 
 
@@ -253,6 +252,7 @@ models_to_register = [
     InterfaceTemplate,
     OperationTemplate,
     ArtifactTemplate,
+    PluginSpecification,
 
     # Service instance models
     Service,
@@ -276,7 +276,6 @@ models_to_register = [
     Parameter,
     Type,
     Metadata,
-    PluginSpecification,
 
     # Orchestration models
     Execution,

--- a/aria/orchestrator/execution_plugin/__init__.py
+++ b/aria/orchestrator/execution_plugin/__init__.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 from contextlib import contextmanager
+from . import instantiation
+
 
 # Populated during execution of python scripts
 ctx = None

--- a/aria/orchestrator/execution_plugin/common.py
+++ b/aria/orchestrator/execution_plugin/common.py
@@ -34,7 +34,7 @@ def download_script(ctx, script_path):
     file_descriptor, dest_script_path = tempfile.mkstemp(suffix='-{0}'.format(suffix))
     os.close(file_descriptor)
     try:
-        if schema in ['http', 'https']:
+        if schema in ('http', 'https'):
             response = requests.get(script_path)
             if response.status_code == 404:
                 ctx.task.abort('Failed to download script: {0} (status code: {1})'

--- a/aria/orchestrator/execution_plugin/instantiation.py
+++ b/aria/orchestrator/execution_plugin/instantiation.py
@@ -1,0 +1,191 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: this module will eventually be moved to a new "aria.instantiation" package
+
+from ...utils.formatting import full_type_name
+from ...utils.collections import OrderedDict
+from ...parser import validation
+from ...parser.consumption import ConsumptionContext
+
+
+def configure_operation(operation):
+    configuration = OrderedDict(operation.configuration) if operation.configuration else {}
+
+    arguments = OrderedDict()
+    arguments['script_path'] = operation.implementation
+    arguments['process'] = _get_process(configuration.pop('process')) \
+        if 'process' in configuration else None
+
+    host = None
+    interface = operation.interface
+    if interface.node is not None:
+        host = interface.node.host
+    elif interface.relationship is not None:
+        if operation.relationship_edge is True:
+            host = interface.relationship.target_node.host
+        else: # either False or None
+            host = interface.relationship.source_node.host
+
+    if host is None:
+        _configure_local(operation)
+    else:
+        _configure_remote(operation, configuration, arguments)
+
+    # Any remaining unhandled configuration values will become extra arguments, available as kwargs
+    # in either "run_script_locally" or "run_script_with_ssh"
+    arguments.update(configuration)
+
+    return arguments
+
+def _configure_local(operation):
+    """
+    Local operation.
+    """
+    from . import operations
+    operation.implementation = '{0}.{1}'.format(operations.__name__,
+                                                operations.run_script_locally.__name__)
+
+
+def _configure_remote(operation, configuration, arguments):
+    """
+    Remote SSH operation via Fabric.
+    """
+    # TODO: find a way to configure these generally in the service template
+    default_user = ''
+    default_password = ''
+
+    ssh = _get_ssh(configuration.pop('ssh')) if 'ssh' in configuration else {}
+    if 'user' not in ssh:
+        ssh['user'] = default_user
+    if ('password' not in ssh) and ('key' not in ssh) and ('key_filename' not in ssh):
+        ssh['password'] = default_password
+
+    arguments['use_sudo'] = ssh.get('use_sudo')
+    arguments['hide_output'] = ssh.get('hide_output')
+    arguments['fabric_env'] = {}
+    if 'warn_only' in ssh:
+        arguments['fabric_env']['warn_only'] = ssh['warn_only']
+    arguments['fabric_env']['user'] = ssh.get('user')
+    arguments['fabric_env']['password'] = ssh.get('password')
+    arguments['fabric_env']['key'] = ssh.get('key')
+    arguments['fabric_env']['key_filename'] = ssh.get('key_filename')
+    if 'address' in ssh:
+        arguments['fabric_env']['host_string'] = ssh['address']
+
+    if arguments['fabric_env'].get('user') is None:
+        context = ConsumptionContext.get_thread_local()
+        context.validation.report('must configure "ssh.user" for "{0}"'
+                                  .format(operation.implementation),
+                                  level=validation.Issue.BETWEEN_TYPES)
+    if (arguments['fabric_env'].get('password') is None) and \
+        (arguments['fabric_env'].get('key') is None) and \
+        (arguments['fabric_env'].get('key_filename') is None):
+        context = ConsumptionContext.get_thread_local()
+        context.validation.report('must configure "ssh.password", "ssh.key", or "ssh.key_filename" '
+                                  'for "{0}"'
+                                  .format(operation.implementation),
+                                  level=validation.Issue.BETWEEN_TYPES)
+
+    from . import operations
+    operation.implementation = '{0}.{1}'.format(operations.__name__,
+                                                operations.run_script_with_ssh.__name__)
+
+
+def _get_process(value):
+    if value is None:
+        return None
+    _validate_type(value, dict, 'process')
+    for k, v in value.iteritems():
+        if k == 'eval_python':
+            value[k] = _str_to_bool(v, 'process.eval_python')
+        elif k == 'cwd':
+            _validate_type(v, basestring, 'process.cwd')
+        elif k == 'command_prefix':
+            _validate_type(v, basestring, 'process.command_prefix')
+        elif k == 'args':
+            value[k] = _dict_to_list(v, 'process.args')
+        elif k == 'env':
+            _validate_type(v, dict, 'process.env')
+        else:
+            context = ConsumptionContext.get_thread_local()
+            context.validation.report('unsupported configuration: "process.{0}"'.format(k),
+                                      level=validation.Issue.BETWEEN_TYPES)
+    return value
+
+
+def _get_ssh(value):
+    if value is None:
+        return {}
+    _validate_type(value, dict, 'ssh')
+    for k, v in value.iteritems():
+        if k == 'use_sudo':
+            value[k] = _str_to_bool(v, 'ssh.use_sudo')
+        elif k == 'hide_output':
+            value[k] = _dict_to_list(v, 'ssh.hide_output')
+        elif k == 'warn_only':
+            value[k] = _str_to_bool(v, 'ssh.warn_only')
+        elif k == 'user':
+            _validate_type(v, basestring, 'ssh.user')
+        elif k == 'password':
+            _validate_type(v, basestring, 'ssh.password')
+        elif k == 'key':
+            _validate_type(v, basestring, 'ssh.key')
+        elif k == 'key_filename':
+            _validate_type(v, basestring, 'ssh.key_filename')
+        elif k == 'address':
+            _validate_type(v, basestring, 'ssh.address')
+        else:
+            context = ConsumptionContext.get_thread_local()
+            context.validation.report('unsupported configuration: "ssh.{0}"'.format(k),
+                                      level=validation.Issue.BETWEEN_TYPES)
+    return value
+
+
+def _validate_type(value, the_type, name):
+    if not isinstance(value, the_type):
+        context = ConsumptionContext.get_thread_local()
+        context.validation.report('"{0}" configuration is not a {1}'
+                                  .format(name, full_type_name(the_type)),
+                                  level=validation.Issue.BETWEEN_TYPES)
+
+
+def _str_to_bool(value, name):
+    if value is None:
+        return None
+    _validate_type(value, basestring, name)
+    if value == 'true':
+        return True
+    elif value == 'false':
+        return False
+    else:
+        context = ConsumptionContext.get_thread_local()
+        context.validation.report('"{0}" configuration is not "true" or "false": {1}'
+                                  .format(name, repr(value)),
+                                  level=validation.Issue.BETWEEN_TYPES)
+
+
+def _dict_to_list(the_dict, name):
+    _validate_type(the_dict, dict, name)
+    value = []
+    for k in sorted(the_dict):
+        v = the_dict[k]
+        if not isinstance(v, basestring):
+            context = ConsumptionContext.get_thread_local()
+            context.validation.report('"{0}.{1}" configuration is not a string: {2}'
+                                      .format(name, k, repr(v)),
+                                      level=validation.Issue.BETWEEN_TYPES)
+        value.append(v)
+    return value

--- a/aria/orchestrator/execution_plugin/ssh/operations.py
+++ b/aria/orchestrator/execution_plugin/ssh/operations.py
@@ -143,9 +143,9 @@ def _fabric_env(ctx, fabric_env, warn_only):
     env = constants.FABRIC_ENV_DEFAULTS.copy()
     env.update(fabric_env or {})
     env.setdefault('warn_only', warn_only)
-    if 'host_string' not in env:
-        env['host_string'] = ctx.task.runs_on.ip
     # validations
+    if (not env.get('host_string')) and (ctx.task) and (ctx.task.actor) and (ctx.task.actor.host):
+        env['host_string'] = ctx.task.actor.host.host_address
     if not env.get('host_string'):
         ctx.task.abort('`host_string` not supplied and ip cannot be deduced automatically')
     if not (env.get('password') or env.get('key_filename') or env.get('key')):

--- a/aria/orchestrator/workflows/api/task_graph.py
+++ b/aria/orchestrator/workflows/api/task_graph.py
@@ -37,7 +37,7 @@ def _filter_out_empty_tasks(func=None):
         return lambda f: _filter_out_empty_tasks(func=f)
 
     def _wrapper(task, *tasks, **kwargs):
-        return func(*(t for t in [task] + list(tasks) if t), **kwargs)
+        return func(*(t for t in (task,) + tuple(tasks) if t), **kwargs)
     return _wrapper
 
 

--- a/aria/orchestrator/workflows/builtin/utils.py
+++ b/aria/orchestrator/workflows/builtin/utils.py
@@ -71,15 +71,13 @@ def relationship_tasks(
         operations.append(
             OperationTask.for_relationship(relationship=relationship,
                                            interface_name=interface_name,
-                                           operation_name=source_operation_name,
-                                           runs_on='source')
+                                           operation_name=source_operation_name)
         )
     if target_operation_name:
         operations.append(
             OperationTask.for_relationship(relationship=relationship,
                                            interface_name=interface_name,
-                                           operation_name=target_operation_name,
-                                           runs_on='target')
+                                           operation_name=target_operation_name)
         )
 
     return operations

--- a/aria/orchestrator/workflows/core/engine.py
+++ b/aria/orchestrator/workflows/core/engine.py
@@ -82,8 +82,8 @@ class Engine(logger.LoggerMixin):
         events.on_cancelling_workflow_signal.send(self._workflow_context)
 
     def _is_cancel(self):
-        return self._workflow_context.execution.status in [models.Execution.CANCELLING,
-                                                           models.Execution.CANCELLED]
+        return self._workflow_context.execution.status in (models.Execution.CANCELLING,
+                                                           models.Execution.CANCELLED)
 
     def _executable_tasks(self):
         now = datetime.utcnow()

--- a/aria/orchestrator/workflows/core/events_handler.py
+++ b/aria/orchestrator/workflows/core/events_handler.py
@@ -125,8 +125,12 @@ def _workflow_cancelling(workflow_context, *args, **kwargs):
 
 
 def _update_node_state_if_necessary(task, is_transitional=False):
-    if task.interface_name in ['tosca.interfaces.node.lifecycle.Standard', 'Standard']:
-        node = task.runs_on
+    # TODO: this is not the right way to check! the interface name is arbitrary
+    # and also will *never* be the type name
+    model_task = task.model_task
+    node = model_task.node if model_task is not None else None
+    if (node is not None) and \
+        (task.interface_name in ('Standard', 'tosca.interfaces.node.lifecycle.Standard')):
         state = node.determine_state(op_name=task.operation_name, is_transitional=is_transitional)
         if state:
             node.state = state

--- a/aria/orchestrator/workflows/core/task.py
+++ b/aria/orchestrator/workflows/core/task.py
@@ -71,11 +71,11 @@ class StubTask(BaseTask):
 
     @property
     def has_ended(self):
-        return self.status in [models.Task.SUCCESS, models.Task.FAILED]
+        return self.status in (models.Task.SUCCESS, models.Task.FAILED)
 
     @property
     def is_waiting(self):
-        return self.status in [models.Task.PENDING, models.Task.RETRYING]
+        return self.status in (models.Task.PENDING, models.Task.RETRYING)
 
 
 class StartWorkflowTask(StubTask):
@@ -133,15 +133,14 @@ class OperationTask(BaseTask):
         task_model = create_task_model(
             name=api_task.name,
             implementation=api_task.implementation,
-            instance=api_task.actor,
+            actor=api_task.actor,
             inputs=api_task.inputs,
             status=base_task_model.PENDING,
             max_attempts=api_task.max_attempts,
             retry_interval=api_task.retry_interval,
             ignore_failure=api_task.ignore_failure,
             plugin=plugin,
-            execution=self._workflow_context.execution,
-            runs_on=api_task.runs_on
+            execution=self._workflow_context.execution
         )
         self._workflow_context.model.task.put(task_model)
 

--- a/aria/orchestrator/workflows/exceptions.py
+++ b/aria/orchestrator/workflows/exceptions.py
@@ -70,13 +70,19 @@ class TaskException(exceptions.AriaError):
     """
 
 
-class OperationNotFoundException(TaskException):
+class TaskCreationException(TaskException):
+    """
+    Could not create the task.
+    """
+
+
+class OperationNotFoundException(TaskCreationException):
     """
     Could not find an operation on the node or relationship.
     """
 
 
-class PluginNotFoundException(TaskException):
+class PluginNotFoundException(TaskCreationException):
     """
     Could not find a plugin matching the plugin specification.
     """

--- a/aria/orchestrator/workflows/executor/process.py
+++ b/aria/orchestrator/workflows/executor/process.py
@@ -177,7 +177,7 @@ class ProcessExecutor(base.BaseExecutor):
                 pythonpath_dirs = [os.path.join(
                     plugin_prefix, 'lib{0}'.format(b),
                     'python{0}.{1}'.format(sys.version_info[0], sys.version_info[1]),
-                    'site-packages') for b in ['', '64']]
+                    'site-packages') for b in ('', '64')]
 
         # Add used supplied directories to injected PYTHONPATH
         pythonpath_dirs.extend(self._python_path)

--- a/aria/parser/consumption/modeling.py
+++ b/aria/parser/consumption/modeling.py
@@ -103,7 +103,7 @@ class InstantiateServiceInstance(Consumer):
     def consume(self):
         if self.context.modeling.template is None:
             self.context.validation.report('InstantiateServiceInstance consumer: missing service '
-                                           'model')
+                                           'template')
             return
 
         self.context.modeling.template.instantiate(None)
@@ -145,6 +145,24 @@ class ValidateCapabilities(Consumer):
         self.context.modeling.instance.validate_capabilities()
 
 
+class FindHosts(Consumer):
+    """
+    Find hosts for all nodes in the service instance.
+    """
+
+    def consume(self):
+        self.context.modeling.instance.find_hosts()
+
+
+class ConfigureOperations(Consumer):
+    """
+    Configures all operations in the service instance.
+    """
+
+    def consume(self):
+        self.context.modeling.instance.configure_operations()
+
+
 class ServiceInstance(ConsumerChain):
     """
     Generates the service instance by instantiating the service template.
@@ -158,6 +176,8 @@ class ServiceInstance(ConsumerChain):
                                                         SatisfyRequirements,
                                                         CoerceServiceInstanceValues,
                                                         ValidateCapabilities,
+                                                        FindHosts,
+                                                        ConfigureOperations,
                                                         CoerceServiceInstanceValues))
 
     def dump(self):

--- a/aria/storage/instrumentation.py
+++ b/aria/storage/instrumentation.py
@@ -110,9 +110,9 @@ class _Instrumentation(object):
                         current = copy.deepcopy(attribute_type(initial))
                     tracked_attributes[attribute_name] = _Value(initial, current)
                 target.__dict__[attribute_name] = tracked_attributes[attribute_name].current
-        for listener_args in [(instrumented_class, 'load', listener),
+        for listener_args in ((instrumented_class, 'load', listener),
                               (instrumented_class, 'refresh', listener),
-                              (instrumented_class, 'refresh_flush', listener)]:
+                              (instrumented_class, 'refresh_flush', listener)):
             sqlalchemy.event.listen(*listener_args)
             self.listeners.append(listener_args)
 

--- a/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/elasticsearch.yaml
+++ b/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/elasticsearch.yaml
@@ -4,3 +4,5 @@ node_types:
 
   tosca.nodes.SoftwareComponent.Elasticsearch:
     derived_from: tosca.nodes.SoftwareComponent
+    capabilities:
+      app: tosca.capabilities.Endpoint

--- a/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/kibana.yaml
+++ b/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/kibana.yaml
@@ -8,3 +8,5 @@ node_types:
       - search_endpoint:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.ConnectsTo
+    capabilities:
+      app: tosca.capabilities.Endpoint

--- a/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/logstash.yaml
+++ b/examples/tosca-simple-1.0/use-cases/multi-tier-1/custom_types/logstash.yaml
@@ -8,3 +8,5 @@ node_types:
       - search_endpoint:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.ConnectsTo
+    capabilities:
+      app: tosca.capabilities.Endpoint

--- a/examples/tosca-simple-1.0/use-cases/webserver-dbms-2/custom_types/paypalpizzastore_nodejs_app.yaml
+++ b/examples/tosca-simple-1.0/use-cases/webserver-dbms-2/custom_types/paypalpizzastore_nodejs_app.yaml
@@ -9,7 +9,7 @@ node_types:
         type: string
     requirements:
       - database_connection:
-          capability: tosca.capabilities.Container
+          capability: tosca.capabilities.Node
 
   tosca.nodes.WebServer.Nodejs:
     derived_from: tosca.nodes.WebServer

--- a/examples/tosca-simple-1.0/use-cases/webserver-dbms-2/webserver-dbms-2.yaml
+++ b/examples/tosca-simple-1.0/use-cases/webserver-dbms-2/webserver-dbms-2.yaml
@@ -53,7 +53,7 @@ topology_template:
              implementation: scripts/nodejs/configure.sh
              inputs:
                github_url: { get_property: [ SELF, github_url ] }
-               mongodb_ip: { get_attribute: [mongo_server, private_address] }
+               mongodb_ip: { get_attribute: [ mongo_server, private_address ] }
            start: scripts/nodejs/start.sh
 
     nodejs:
@@ -86,7 +86,7 @@ topology_template:
           configure:
             implementation: mongodb/config.sh
             inputs:
-              mongodb_ip: { get_attribute: [mongo_server, private_address] }
+              mongodb_ip: { get_attribute: [ mongo_server, private_address ] }
           start: mongodb/start.sh
 
     mongo_server:
@@ -109,7 +109,7 @@ topology_template:
 
     nodejs_url:
       description: URL for the nodejs server, http://<IP>:3000
-      value: { get_attribute: [app_server, private_address] }
+      value: { get_attribute: [ app_server, private_address ] }
     mongodb_url:
       description: URL for the mongodb server.
       value: { get_attribute: [ mongo_server, private_address ] }

--- a/extensions/aria_extension_tosca/profiles/aria-1.0/aria-1.0.yaml
+++ b/extensions/aria_extension_tosca/profiles/aria-1.0/aria-1.0.yaml
@@ -17,6 +17,8 @@ policy_types:
 
   aria.Plugin:
     _extensions:
+      shorthand_name: Plugin
+      type_qualified_name: aria:Plugin
       role: plugin
     description: >-
       Policy used to specify plugins used by services. For an operation to be able to use a plugin
@@ -29,9 +31,17 @@ policy_types:
           Minimum plugin version.
         type: version
         required: false
+      enabled:
+        description: >-
+          If the policy is to disable the plugin then it will be ignored and all operations and
+          workflows depending on it will also be disabled.
+        type: boolean
+        default: true
 
   aria.Workflow:
     _extensions:
+      shorthand_name: Workflow
+      type_qualified_name: aria:Workflow
       role: workflow
     description: >-
       Policy used to specify custom workflows. A workflow is usually a workload of interconnected

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/capabilities.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/capabilities.yaml
@@ -32,6 +32,7 @@ capability_types:
       specification: tosca-simple-1.0
       specification_section: 5.4.2
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_CAPABILITIES_NODE'
+      role: feature
     description: >-
       The Node capability indicates the base capabilities of a TOSCA Node Type.
     derived_from: tosca.capabilities.Root
@@ -43,6 +44,7 @@ capability_types:
       specification: tosca-simple-1.0
       specification_section: 5.4.3
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_CAPABILITIES_CONTAINER'
+      role: host
     description: >-
       The Container capability, when included on a Node Type or Template definition, indicates that the node can act as a container
       for (or a host for) one or more other declared Node Types.

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/interfaces.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/interfaces.yaml
@@ -63,24 +63,40 @@ interface_types:
     pre_configure_source:
       description: >-
         Operation to pre-configure the source endpoint.
+      _extensions:
+        relationship_edge: source
     pre_configure_target:
       description: >-
         Operation to pre-configure the target endpoint.
+      _extensions:
+        relationship_edge: target
     post_configure_source:
       description: >-
         Operation to post-configure the source endpoint.
+      _extensions:
+        relationship_edge: source
     post_configure_target:
       description: >-
         Operation to post-configure the target endpoint.
+      _extensions:
+        relationship_edge: target
     add_target:
       description: >-
         Operation to notify the source node of a target node being added via a relationship.
+      _extensions:
+        relationship_edge: source
     add_source:
       description: >-
         Operation to notify the target node of a source node which is now available via a relationship.
+      _extensions:
+        relationship_edge: target
     target_changed:
       description: >-
         Operation to notify source some property or attribute of the target changed
+      _extensions:
+        relationship_edge: source
     remove_target:
       description: >-
         Operation to remove a target node.
+      _extensions:
+        relationship_edge: source

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/nodes.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/nodes.yaml
@@ -60,6 +60,7 @@ node_types:
       specification: tosca-simple-1.0
       specification_section: 5.8.2
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_NODES_COMPUTE'
+      role: host
     description: >-
       The TOSCA Compute node represents one or more real or virtual processors of software applications or services along with
       other essential local resources. Collectively, the resources the compute node represents can logically be viewed as a (real

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/capabilities.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/capabilities.py
@@ -78,6 +78,11 @@ def get_inherited_capability_definitions(context, presentation, for_presentation
                 #capability_definitions[capability_name] = capability_definition
             else:
                 capability_definition = our_capability_definition._clone(for_presentation)
+                if isinstance(capability_definition._raw, basestring):
+                    # Make sure we have a dict
+                    the_type = capability_definition._raw
+                    capability_definition._raw = OrderedDict()
+                    capability_definition._raw['type'] = the_type
                 capability_definitions[capability_name] = capability_definition
 
             merge_capability_definition_from_type(context, presentation, capability_definition)

--- a/tests/orchestrator/context/test_operation.py
+++ b/tests/orchestrator/context/test_operation.py
@@ -230,7 +230,6 @@ def test_plugin_workdir(ctx, thread_executor, tmpdir):
 
     plugin = mock.models.create_plugin()
     ctx.model.plugin.put(plugin)
-    plugin_specification = mock.models.create_plugin_specification()
     node = ctx.model.node.get_by_name(mock.models.DEPENDENCY_NODE_NAME)
     interface = mock.models.create_interface(
         node.service,
@@ -238,7 +237,7 @@ def test_plugin_workdir(ctx, thread_executor, tmpdir):
         operation_name,
         operation_kwargs=dict(
             implementation='{0}.{1}'.format(__name__, _test_plugin_workdir.__name__),
-            plugin_specification=plugin_specification)
+            plugin=plugin)
     )
     node.interfaces[interface.name] = interface
     ctx.model.node.update(node)

--- a/tests/orchestrator/context/test_serialize.py
+++ b/tests/orchestrator/context/test_serialize.py
@@ -45,13 +45,12 @@ def _mock_workflow(ctx, graph):
     node = ctx.model.node.get_by_name(mock.models.DEPENDENCY_NODE_NAME)
     plugin = mock.models.create_plugin()
     ctx.model.plugin.put(plugin)
-    plugin_specification = mock.models.create_plugin_specification()
     interface = mock.models.create_interface(
         node.service,
         'test',
         'op',
         operation_kwargs=dict(implementation=_operation_mapping(),
-                              plugin_specification=plugin_specification)
+                              plugin=plugin)
     )
     node.interfaces[interface.name] = interface
     task = api.task.OperationTask.for_node(node=node, interface_name='test', operation_name='op')

--- a/tests/orchestrator/execution_plugin/test_ssh.py
+++ b/tests/orchestrator/execution_plugin/test_ssh.py
@@ -292,12 +292,13 @@ class TestFabricEnvHideGroupsAndRunCommands(object):
         assert self.mock.settings_merged['timeout'] == timeout
 
     def test_implicit_host_string(self, mocker):
-        expected_ip = '1.1.1.1'
-        mocker.patch.object(self._Ctx.task.runs_on, 'ip', expected_ip)
+        expected_host_address = '1.1.1.1'
+        mocker.patch.object(self._Ctx.task.actor, 'host')
+        mocker.patch.object(self._Ctx.task.actor.host, 'host_address', expected_host_address)
         fabric_env = self.default_fabric_env.copy()
         del fabric_env['host_string']
         self._run(fabric_env=fabric_env)
-        assert self.mock.settings_merged['host_string'] == expected_ip
+        assert self.mock.settings_merged['host_string'] == expected_host_address
 
     def test_explicit_host_string(self):
         fabric_env = self.default_fabric_env.copy()
@@ -409,13 +410,15 @@ class TestFabricEnvHideGroupsAndRunCommands(object):
             raise RuntimeError
 
     class _Ctx(object):
-        class Stub(object):
+        class Task(object):
             @staticmethod
             def abort(message=None):
                 models.Task.abort(message)
-            ip = None
-        task = Stub
-        task.runs_on = Stub
+            actor = None
+        class Actor(object):
+            host = None
+        task = Task
+        task.actor = Actor
         logger = logging.getLogger()
 
     @staticmethod

--- a/tests/orchestrator/workflows/api/test_task.py
+++ b/tests/orchestrator/workflows/api/test_task.py
@@ -18,7 +18,6 @@ import pytest
 
 from aria.orchestrator import context
 from aria.orchestrator.workflows import api
-from aria.modeling import models
 
 from tests import mock, storage
 
@@ -45,13 +44,11 @@ class TestOperationTask(object):
         plugin = mock.models.create_plugin('test_plugin', '0.1')
         ctx.model.node.update(plugin)
 
-        plugin_specification = mock.models.create_plugin_specification('test_plugin', '0.1')
-
         interface = mock.models.create_interface(
             ctx.service,
             interface_name,
             operation_name,
-            operation_kwargs=dict(plugin_specification=plugin_specification,
+            operation_kwargs=dict(plugin=plugin,
                                   implementation='op_path'))
 
         node = ctx.model.node.get_by_name(mock.models.DEPENDENT_NODE_NAME)
@@ -85,7 +82,6 @@ class TestOperationTask(object):
         assert api_task.max_attempts == max_attempts
         assert api_task.ignore_failure == ignore_failure
         assert api_task.plugin.name == 'test_plugin'
-        assert api_task.runs_on == models.Task.RUNS_ON_NODE
 
     def test_source_relationship_operation_task_creation(self, ctx):
         interface_name = 'test_interface'
@@ -94,13 +90,11 @@ class TestOperationTask(object):
         plugin = mock.models.create_plugin('test_plugin', '0.1')
         ctx.model.plugin.update(plugin)
 
-        plugin_specification = mock.models.create_plugin_specification('test_plugin', '0.1')
-
         interface = mock.models.create_interface(
             ctx.service,
             interface_name,
             operation_name,
-            operation_kwargs=dict(plugin_specification=plugin_specification,
+            operation_kwargs=dict(plugin=plugin,
                                   implementation='op_path')
         )
 
@@ -131,7 +125,6 @@ class TestOperationTask(object):
         assert api_task.retry_interval == retry_interval
         assert api_task.max_attempts == max_attempts
         assert api_task.plugin.name == 'test_plugin'
-        assert api_task.runs_on == models.Task.RUNS_ON_SOURCE
 
     def test_target_relationship_operation_task_creation(self, ctx):
         interface_name = 'test_interface'
@@ -140,13 +133,11 @@ class TestOperationTask(object):
         plugin = mock.models.create_plugin('test_plugin', '0.1')
         ctx.model.node.update(plugin)
 
-        plugin_specification = mock.models.create_plugin_specification('test_plugin', '0.1')
-
         interface = mock.models.create_interface(
             ctx.service,
             interface_name,
             operation_name,
-            operation_kwargs=dict(plugin_specification=plugin_specification,
+            operation_kwargs=dict(plugin=plugin,
                                   implementation='op_path')
         )
 
@@ -163,8 +154,7 @@ class TestOperationTask(object):
                 operation_name=operation_name,
                 inputs=inputs,
                 max_attempts=max_attempts,
-                retry_interval=retry_interval,
-                runs_on=models.Task.RUNS_ON_TARGET)
+                retry_interval=retry_interval)
 
         assert api_task.name == api.task.OperationTask.NAME_FORMAT.format(
             type='relationship',
@@ -178,7 +168,6 @@ class TestOperationTask(object):
         assert api_task.retry_interval == retry_interval
         assert api_task.max_attempts == max_attempts
         assert api_task.plugin.name == 'test_plugin'
-        assert api_task.runs_on == models.Task.RUNS_ON_TARGET
 
     def test_operation_task_default_values(self, ctx):
         interface_name = 'test_interface'
@@ -187,15 +176,13 @@ class TestOperationTask(object):
         plugin = mock.models.create_plugin('package', '0.1')
         ctx.model.node.update(plugin)
 
-        plugin_specification = mock.models.create_plugin_specification('package', '0.1')
-
         dependency_node = ctx.model.node.get_by_name(mock.models.DEPENDENCY_NODE_NAME)
 
         interface = mock.models.create_interface(
             ctx.service,
             interface_name,
             operation_name,
-            operation_kwargs=dict(plugin_specification=plugin_specification,
+            operation_kwargs=dict(plugin=plugin,
                                   implementation='op_path'))
         dependency_node.interfaces[interface_name] = interface
 
@@ -210,7 +197,6 @@ class TestOperationTask(object):
         assert task.max_attempts == ctx._task_max_attempts
         assert task.ignore_failure == ctx._task_ignore_failure
         assert task.plugin is plugin
-        assert task.runs_on == models.Task.RUNS_ON_NODE
 
 
 class TestWorkflowTask(object):

--- a/tests/orchestrator/workflows/builtin/__init__.py
+++ b/tests/orchestrator/workflows/builtin/__init__.py
@@ -31,16 +31,13 @@ def _assert_relationships(operations, expected_op_full_name, relationships=0):
         # suffix once
         operation = next(operations)
         relationship_id_1 = operation.actor.id
-        edge1 = operation.runs_on
         _assert_cfg_interface_op(operation, expected_op_name)
 
         operation = next(operations)
         relationship_id_2 = operation.actor.id
-        edge2 = operation.runs_on
         _assert_cfg_interface_op(operation, expected_op_name)
 
         assert relationship_id_1 == relationship_id_2
-        assert edge1 != edge2
 
 
 def assert_node_install_operations(operations, relationships=0):

--- a/tests/orchestrator/workflows/builtin/test_execute_operation.py
+++ b/tests/orchestrator/workflows/builtin/test_execute_operation.py
@@ -34,7 +34,8 @@ def test_execute_operation(ctx):
     interface = mock.models.create_interface(
         ctx.service,
         interface_name,
-        operation_name
+        operation_name,
+        operation_kwargs={'implementation': 'test'}
     )
     node.interfaces[interface.name] = interface
     ctx.model.node.update(node)

--- a/tests/orchestrator/workflows/core/test_task_graph_into_exececution_graph.py
+++ b/tests/orchestrator/workflows/core/test_task_graph_into_exececution_graph.py
@@ -30,7 +30,8 @@ def test_task_graph_into_execution_graph(tmpdir):
     interface = mock.models.create_interface(
         node.service,
         interface_name,
-        operation_name
+        operation_name,
+        operation_kwargs={'implementation': 'test'}
     )
     node.interfaces[interface.name] = interface
     task_context.model.node.update(node)

--- a/tests/orchestrator/workflows/executor/test_executor.py
+++ b/tests/orchestrator/workflows/executor/test_executor.py
@@ -119,6 +119,7 @@ class MockTask(object):
         self.ignore_failure = False
         self.interface_name = 'interface_name'
         self.operation_name = 'operation_name'
+        self.model_task = None
 
         for state in models.Task.STATES:
             setattr(self, state.upper(), state)

--- a/tests/orchestrator/workflows/executor/test_process_executor.py
+++ b/tests/orchestrator/workflows/executor/test_process_executor.py
@@ -142,6 +142,7 @@ class MockTask(object):
         self.ignore_failure = False
         self.interface_name = 'interface_name'
         self.operation_name = 'operation_name'
+        self.model_task = None
 
         for state in aria_models.Task.STATES:
             setattr(self, state.upper(), state)

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
@@ -154,14 +154,33 @@ topology_template:
                 - scalable:
                     properties:
                       - max_instances: { greater_or_equal: 8 }
-    
+            relationship:
+              interfaces:
+                Configure:
+                  target_changed:
+                    implementation:
+                      primary: changed.sh
+                      dependencies:
+                        #- { concat: [ process.args.1 >, mongodb ] }
+                        - process.args.1 > mongodb
+                        - process.args.2 > host
+                        - ssh.user > admin
+                        - ssh.password > 1234
+                        - ssh.use_sudo > true
+
+    nginx:
+      type: nginx.Nginx
+      requirements:
+        - host: loadbalancer_host
+        - feature: loadbalancer
+
+    # Features
+
     loadbalancer:
       type: nginx.LoadBalancer
       properties:
-        algorithm: round-robin      
-      requirements:
-        - host: loadbalancer_host
-    
+        algorithm: round-robin   
+
     # Hosts
 
     loadbalancer_host:
@@ -177,7 +196,11 @@ topology_template:
         Standard:
           inputs:
             openstack_credential: { get_input: openstack_credential }
-          configure: juju > charm.loadbalancer
+          configure:
+            implementation:
+              primary: juju > run_charm
+              dependencies:
+                - charm > loadbalancer
 
     application_host:
       copy: loadbalancer_host
@@ -253,6 +276,7 @@ topology_template:
       type: aria.Plugin
       properties:
         version: 1.0
+        enabled: false
 
     maintenance_on:
       type: MaintenanceWorkflow

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/nginx.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/nginx.yaml
@@ -15,12 +15,15 @@
 
 node_types:
 
+  nginx.Nginx:
+    description: >-
+      Nginx instance.
+    derived_from: tosca.nodes.SoftwareComponent
+    requirements:
+      - feature:
+          capability: tosca.capabilities.Node
+
   nginx.LoadBalancer:
     description: >-
-      Nginx as a loadbalancer.
+      Nginx loadbalancer feature.
     derived_from: tosca.nodes.LoadBalancer
-    requirements:
-      - host:
-          capability: tosca.capabilities.Container
-          node: tosca.nodes.Compute
-          relationship: tosca.relationships.HostedOn


### PR DESCRIPTION
Main changes:

1. Removed `runs_on` field from task model and API
2. Two new instantiations phase, one to find the host nodes, and the second to configure operation instances for the execution plugin
3. Parser fills in `configuration` field in `OperationTemplate` using `dependencies` in TOSCA syntax
4. Fixes to reqs-and-caps bugs