### PR TITLE
ARIA-150 Fixed simple hello-world example

### DIFF
--- a/examples/hello-world/helloworld.yaml
+++ b/examples/hello-world/helloworld.yaml
@@ -1,18 +1,23 @@
-tosca_definitions_version: tosca_simple_profile_for_nfv_1_0
+tosca_definitions_version: tosca_simple_yaml_1_0
 
 node_types:
+  web_server:
+    derived_from: tosca.nodes.Root
+    capabilities:
+      host:
+        type: tosca.capabilities.Container
+
   web_app:
     derived_from: tosca.nodes.WebApplication
     properties:
       port:
         type: integer
-        default: 8080
 
 topology_template:
 
   node_templates:
     web_server:
-      type: tosca.nodes.WebServer
+      type: web_server
 
     web_app:
       type: web_app


### PR DESCRIPTION
The simple hello-world example had a missing host node,
which caused an error at service creation phase.
The example now uses custom types which do not require
the extra host node.