### PR TITLE
ARIA-139 Support attributes

### DIFF
--- a/aria/core.py
+++ b/aria/core.py
@@ -77,10 +77,14 @@ class Core(object):
             consumption.ConsumerChain(
                 context,
                 (
+                    consumption.CoerceServiceInstanceValues,
+                    consumption.ValidateServiceInstance,
                     consumption.SatisfyRequirements,
+                    consumption.CoerceServiceInstanceValues,
                     consumption.ValidateCapabilities,
                     consumption.FindHosts,
-                    consumption.ConfigureOperations
+                    consumption.ConfigureOperations,
+                    consumption.CoerceServiceInstanceValues
                 )).consume()
             if context.validation.dump_issues():
                 raise exceptions.InstantiationError('Failed to instantiate service template')

--- a/aria/modeling/contraints.py
+++ b/aria/modeling/contraints.py
@@ -13,18 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .specification import implements_specification, iter_specifications
 
+class NodeTemplateConstraint(object):
+    """
+    Used to constrain requirements for node templates.
 
-MODULES = (
-    'consumption',
-    'loading',
-    'modeling',
-    'presentation',
-    'reading',
-    'validation')
+    Must be serializable.
+    """
 
-__all__ = (
-    'MODULES',
-    'implements_specification',
-    'iter_specifications')
+    def matches(self, source_node_template, target_node_template):
+        """
+        Returns true is the target matches the constraint for the source.
+        """
+        raise NotImplementedError

--- a/aria/modeling/functions.py
+++ b/aria/modeling/functions.py
@@ -13,20 +13,118 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ..parser.consumption import ConsumptionContext
+from ..parser.exceptions import InvalidValueError
+from ..utils.collections import OrderedDict
+from . import exceptions
+
+
 class Function(object):
     """
-    An intrinsic function.
+    Base class for intrinsic functions. Serves as a placeholder for a value that should eventually
+    be derived by "evaluating" (calling) the function.
 
-    Serves as a placeholder for a value that should eventually be derived by calling the function.
+    Note that this base class is provided as a convenience and you do not have to inherit it: any
+    object with an ``__evaluate__`` method would be treated similarly.
     """
 
     @property
     def as_raw(self):
         raise NotImplementedError
 
-    def _evaluate(self, context, container):
+    def __evaluate__(self, container_holder):
+        """
+        Evaluates the function if possible. If impossible, raises
+        :class:`CannotEvaluateFunctionException` (do not just return None).
+
+        :rtype: Evaluation (or any object with ``value`` and ``final`` properties)
+        """
+
         raise NotImplementedError
 
     def __deepcopy__(self, memo):
         # Circumvent cloning in order to maintain our state
         return self
+
+
+class Evaluation(object):
+    """
+    An evaluated :class:`Function` return value.
+    """
+
+    def __init__(self, value, final=False):
+        self.value = value
+        self.final = final
+
+
+def evaluate(value, container_holder, report_issues=False): # pylint: disable=too-many-branches
+    """
+    Recursively attempts to call ``__evaluate__``. If an evaluation occurred will return an
+    :class:`Evaluation`, otherwise it will be None. If any evaluation is non-final, then the entire
+    evaluation will also be non-final.
+
+    The ``container_holder`` argument should have three properties: ``container`` should return
+    the model that contains the value, ``service`` should return the containing
+    :class:`aria.modeling.models.Service` model or None, and ``service_template`` should return the
+    containing :class:`aria.modeling.models.ServiceTemplate` model or None.
+    """
+
+    evaluated = False
+    final = True
+
+    if hasattr(value, '__evaluate__'):
+        try:
+            evaluation = value.__evaluate__(container_holder)
+
+            # Verify evaluation structure
+            if (evaluation is None) \
+                or (not hasattr(evaluation, 'value')) \
+                or (not hasattr(evaluation, 'final')):
+                raise InvalidValueError('bad __evaluate__ implementation')
+
+            evaluated = True
+            value = evaluation.value
+            final = evaluation.final
+
+            # The evaluated value might itself be evaluable
+            evaluation = evaluate(value, container_holder, report_issues)
+            if evaluation is not None:
+                value = evaluation.value
+                if not evaluation.final:
+                    final = False
+        except exceptions.CannotEvaluateFunctionException:
+            pass
+        except InvalidValueError as e:
+            if report_issues:
+                context = ConsumptionContext.get_thread_local()
+                context.validation.report(e.issue)
+
+    elif isinstance(value, list):
+        evaluated_list = []
+        for v in value:
+            evaluation = evaluate(v, container_holder, report_issues)
+            if evaluation is not None:
+                evaluated_list.append(evaluation.value)
+                evaluated = True
+                if not evaluation.final:
+                    final = False
+            else:
+                evaluated_list.append(v)
+        if evaluated:
+            value = evaluated_list
+
+    elif isinstance(value, dict):
+        evaluated_dict = OrderedDict()
+        for k, v in value.iteritems():
+            evaluation = evaluate(v, container_holder, report_issues)
+            if evaluation is not None:
+                evaluated_dict[k] = evaluation.value
+                evaluated = True
+                if not evaluation.final:
+                    final = False
+            else:
+                evaluated_dict[k] = v
+        if evaluated:
+            value = evaluated_dict
+
+    return Evaluation(value, final) if evaluated else None

--- a/aria/modeling/mixins.py
+++ b/aria/modeling/mixins.py
@@ -124,7 +124,7 @@ class InstanceModelMixin(ModelMixin):
     def validate(self):
         pass
 
-    def coerce_values(self, container, report_issues):
+    def coerce_values(self, report_issues):
         pass
 
     def dump(self):

--- a/aria/modeling/relationship.py
+++ b/aria/modeling/relationship.py
@@ -146,13 +146,18 @@ def one_to_one(model_class,
                        false to disable
     :type back_populates: basestring|bool
     """
-    if back_populates is None:
-        back_populates = model_class.__tablename__
+    backref_kwargs = None
+    if back_populates is not NO_BACK_POP:
+        if back_populates is None:
+            back_populates = model_class.__tablename__
+        backref_kwargs = {'name': back_populates, 'uselist': False}
+        back_populates = None
 
     return _relationship(model_class,
                          other_table,
                          fk=fk,
                          back_populates=back_populates,
+                         backref_kwargs=backref_kwargs,
                          other_fk=other_fk)
 
 
@@ -190,6 +195,7 @@ def one_to_many(model_class,
     rel_kwargs.setdefault('cascade', 'all')
     if back_populates is None:
         back_populates = model_class.__tablename__
+
     return _relationship(
         model_class,
         child_table,
@@ -330,10 +336,11 @@ def _relationship(model_class,
 
     if backref_kwargs:
         assert back_populates is None
-        return relationship(lambda: _get_class_for_table(model_class, other_table_name),
-                            backref=backref(**backref_kwargs),
-                            **relationship_kwargs
-                           )
+        return relationship(
+            lambda: _get_class_for_table(model_class, other_table_name),
+            backref=backref(**backref_kwargs),
+            **relationship_kwargs
+        )
     else:
         if back_populates is not NO_BACK_POP:
             relationship_kwargs['back_populates'] = back_populates

--- a/aria/modeling/service_instance.py
+++ b/aria/modeling/service_instance.py
@@ -251,16 +251,16 @@ class ServiceBase(InstanceModelMixin):
         utils.validate_dict_values(self.outputs)
         utils.validate_dict_values(self.workflows)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.meta_data, report_issues)
-        utils.coerce_dict_values(container, self.nodes, report_issues)
-        utils.coerce_dict_values(container, self.groups, report_issues)
-        utils.coerce_dict_values(container, self.policies, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.meta_data, report_issues)
+        utils.coerce_dict_values(self.nodes, report_issues)
+        utils.coerce_dict_values(self.groups, report_issues)
+        utils.coerce_dict_values(self.policies, report_issues)
         if self.substitution is not None:
-            self.substitution.coerce_values(container, report_issues)
-        utils.coerce_dict_values(container, self.inputs, report_issues)
-        utils.coerce_dict_values(container, self.outputs, report_issues)
-        utils.coerce_dict_values(container, self.workflows, report_issues)
+            self.substitution.coerce_values(report_issues)
+        utils.coerce_dict_values(self.inputs, report_issues)
+        utils.coerce_dict_values(self.outputs, report_issues)
+        utils.coerce_dict_values(self.workflows, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -513,6 +513,10 @@ class NodeBase(InstanceModelMixin):
     def properties(cls):
         return relationship.many_to_many(cls, 'parameter', prefix='properties', dict_key='name')
 
+    @declared_attr
+    def attributes(cls):
+        return relationship.many_to_many(cls, 'parameter', prefix='attributes', dict_key='name')
+
     # endregion
 
     description = Column(Text)
@@ -646,6 +650,7 @@ class NodeBase(InstanceModelMixin):
             ('name', self.name),
             ('type_name', self.type.name),
             ('properties', formatting.as_raw_dict(self.properties)),
+            ('attributes', formatting.as_raw_dict(self.properties)),
             ('interfaces', formatting.as_raw_list(self.interfaces)),
             ('artifacts', formatting.as_raw_list(self.artifacts)),
             ('capabilities', formatting.as_raw_list(self.capabilities)),
@@ -664,17 +669,19 @@ class NodeBase(InstanceModelMixin):
         # TODO: validate that node template is of type?
 
         utils.validate_dict_values(self.properties)
+        utils.validate_dict_values(self.attributes)
         utils.validate_dict_values(self.interfaces)
         utils.validate_dict_values(self.artifacts)
         utils.validate_dict_values(self.capabilities)
         utils.validate_list_values(self.outbound_relationships)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(self, self.properties, report_issues)
-        utils.coerce_dict_values(self, self.interfaces, report_issues)
-        utils.coerce_dict_values(self, self.artifacts, report_issues)
-        utils.coerce_dict_values(self, self.capabilities, report_issues)
-        utils.coerce_list_values(self, self.outbound_relationships, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
+        utils.coerce_dict_values(self.attributes, report_issues)
+        utils.coerce_dict_values(self.interfaces, report_issues)
+        utils.coerce_dict_values(self.artifacts, report_issues)
+        utils.coerce_dict_values(self.capabilities, report_issues)
+        utils.coerce_list_values(self.outbound_relationships, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -683,6 +690,7 @@ class NodeBase(InstanceModelMixin):
             console.puts('Type: {0}'.format(context.style.type(self.type.name)))
             console.puts('Template: {0}'.format(context.style.node(self.node_template.name)))
             utils.dump_dict_values(self.properties, 'Properties')
+            utils.dump_dict_values(self.attributes, 'Attributes')
             utils.dump_interfaces(self.interfaces)
             utils.dump_dict_values(self.artifacts, 'Artifacts')
             utils.dump_dict_values(self.capabilities, 'Capabilities')
@@ -797,9 +805,9 @@ class GroupBase(InstanceModelMixin):
         utils.validate_dict_values(self.properties)
         utils.validate_dict_values(self.interfaces)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.properties, report_issues)
-        utils.coerce_dict_values(container, self.interfaces, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
+        utils.coerce_dict_values(self.interfaces, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -916,8 +924,8 @@ class PolicyBase(InstanceModelMixin):
     def validate(self):
         utils.validate_dict_values(self.properties)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.properties, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1017,8 +1025,8 @@ class SubstitutionBase(InstanceModelMixin):
     def validate(self):
         utils.validate_dict_values(self.mappings)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.mappings, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.mappings, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1121,7 +1129,7 @@ class SubstitutionMappingBase(InstanceModelMixin):
         return collections.OrderedDict((
             ('name', self.name)))
 
-    def coerce_values(self, container, report_issues):
+    def coerce_values(self, report_issues):
         pass
 
     def validate(self):
@@ -1311,9 +1319,9 @@ class RelationshipBase(InstanceModelMixin):
         utils.validate_dict_values(self.properties)
         utils.validate_dict_values(self.interfaces)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.properties, report_issues)
-        utils.coerce_dict_values(container, self.interfaces, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
+        utils.coerce_dict_values(self.interfaces, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1451,8 +1459,8 @@ class CapabilityBase(InstanceModelMixin):
     def validate(self):
         utils.validate_dict_values(self.properties)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.properties, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1598,9 +1606,9 @@ class InterfaceBase(InstanceModelMixin):
         utils.validate_dict_values(self.inputs)
         utils.validate_dict_values(self.operations)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.inputs, report_issues)
-        utils.coerce_dict_values(container, self.operations, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.inputs, report_issues)
+        utils.coerce_dict_values(self.operations, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1765,8 +1773,8 @@ class OperationBase(InstanceModelMixin):
         # TODO must be associated with interface or service
         utils.validate_dict_values(self.inputs)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.inputs, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.inputs, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()
@@ -1905,8 +1913,8 @@ class ArtifactBase(InstanceModelMixin):
     def validate(self):
         utils.validate_dict_values(self.properties)
 
-    def coerce_values(self, container, report_issues):
-        utils.coerce_dict_values(container, self.properties, report_issues)
+    def coerce_values(self, report_issues):
+        utils.coerce_dict_values(self.properties, report_issues)
 
     def dump(self):
         context = ConsumptionContext.get_thread_local()

--- a/aria/orchestrator/execution_plugin/instantiation.py
+++ b/aria/orchestrator/execution_plugin/instantiation.py
@@ -15,7 +15,7 @@
 
 # TODO: this module will eventually be moved to a new "aria.instantiation" package
 
-from ...utils.formatting import full_type_name
+from ...utils.type import full_type_name
 from ...utils.collections import OrderedDict
 from ...parser import validation
 from ...parser.consumption import ConsumptionContext

--- a/aria/parser/consumption/__init__.py
+++ b/aria/parser/consumption/__init__.py
@@ -28,9 +28,11 @@ from .modeling import (
     Types,
     ServiceInstance,
     FindHosts,
+    ValidateServiceInstance,
     ConfigureOperations,
     SatisfyRequirements,
-    ValidateCapabilities
+    ValidateCapabilities,
+    CoerceServiceInstanceValues
 )
 from .inputs import Inputs
 
@@ -45,7 +47,10 @@ __all__ = (
     'ServiceTemplate',
     'Types',
     'ServiceInstance',
-    'Inputs',
+    'FindHosts',
+    'ValidateServiceInstance',
+    'ConfigureOperations',
     'SatisfyRequirements',
-    'ValidateCapabilities'
+    'ValidateCapabilities',
+    'CoerceServiceInstanceValues'
 )

--- a/aria/parser/consumption/modeling.py
+++ b/aria/parser/consumption/modeling.py
@@ -42,7 +42,7 @@ class CoerceServiceTemplateValues(Consumer):
     """
 
     def consume(self):
-        self.context.modeling.template.coerce_values(None, True)
+        self.context.modeling.template.coerce_values(True)
 
 
 class ValidateServiceTemplate(Consumer):
@@ -116,7 +116,7 @@ class CoerceServiceInstanceValues(Consumer):
     """
 
     def consume(self):
-        self.context.modeling.instance.coerce_values(None, True)
+        self.context.modeling.instance.coerce_values(True)
 
 
 class ValidateServiceInstance(Consumer):

--- a/aria/parser/presentation/fields.py
+++ b/aria/parser/presentation/fields.py
@@ -21,7 +21,8 @@ from ...exceptions import AriaException
 from ...utils.collections import FrozenDict, FrozenList, deepcopy_with_locators, merge, OrderedDict
 from ...utils.caching import cachedmethod
 from ...utils.console import puts
-from ...utils.formatting import as_raw, safe_repr, full_type_name
+from ...utils.formatting import as_raw, safe_repr
+from ...utils.type import full_type_name
 from ...utils.exceptions import print_exception
 from ..exceptions import InvalidValueError
 

--- a/aria/parser/presentation/presentation.py
+++ b/aria/parser/presentation/presentation.py
@@ -15,7 +15,8 @@
 
 from ...utils.caching import HasCachedMethods
 from ...utils.collections import deepcopy_with_locators
-from ...utils.formatting import full_type_name, safe_repr
+from ...utils.formatting import safe_repr
+from ...utils.type import full_type_name
 from ...utils.console import puts
 from ..validation import Issue
 from .null import none_to_null

--- a/aria/parser/presentation/utils.py
+++ b/aria/parser/presentation/utils.py
@@ -15,7 +15,8 @@
 
 from types import FunctionType
 
-from ...utils.formatting import full_type_name, safe_repr
+from ...utils.formatting import safe_repr
+from ...utils.type import full_type_name
 from ..validation import Issue
 from .null import NULL
 

--- a/aria/parser/specification.py
+++ b/aria/parser/specification.py
@@ -17,40 +17,7 @@ import re
 
 from ..extension import parser
 from ..utils.collections import OrderedDict
-from ..utils.formatting import full_type_name
-
-_DSL_SPECIFICATIONS = {}
-
-
-def dsl_specification(section, spec):
-    """
-    Decorator for TOSCA specification.
-
-    Used for documentation and standards compliance.
-    """
-    def decorator(obj):
-        specification = _DSL_SPECIFICATIONS.get(spec)
-
-        if specification is None:
-            specification = {}
-            _DSL_SPECIFICATIONS[spec] = specification
-
-        if section in specification:
-            raise Exception('you cannot specify the same @dsl_specification twice, consider'
-                            ' adding \'-1\', \'-2\', etc.: %s, %s' % (spec, section))
-
-        specification[section] = OrderedDict((
-            ('code', full_type_name(obj)),
-            ('doc', obj.__doc__)))
-
-        try:
-            setattr(obj, '_dsl_specifications', {section: section, spec: spec})
-        except BaseException:
-            pass
-
-        return obj
-
-    return decorator
+from ..utils.specification import (DSL_SPECIFICATIONS, implements_specification) # pylint: disable=unused-import
 
 
 def iter_specifications():
@@ -63,11 +30,9 @@ def iter_specifications():
             details['code'] = sections[k]['code']
             yield k, _fix_details(sections[k], spec)
 
-    for spec, sections in _DSL_SPECIFICATIONS.iteritems():
+    for spec, sections in DSL_SPECIFICATIONS.iteritems():
         yield spec, iter_sections(spec, sections)
 
-
-# Utils
 
 def _section_key(value):
     try:

--- a/aria/parser/validation/issue.py
+++ b/aria/parser/validation/issue.py
@@ -16,7 +16,7 @@
 from __future__ import absolute_import  # so we can import standard 'collections'
 
 from ...utils.collections import OrderedDict
-from ...utils.formatting import full_type_name
+from ...utils.type import full_type_name
 
 
 class Issue(object):

--- a/aria/utils/formatting.py
+++ b/aria/utils/formatting.py
@@ -71,18 +71,6 @@ class YamlAsRawDumper(yaml.dumper.RoundTripDumper):  # pylint: disable=too-many-
         return super(YamlAsRawDumper, self).represent_data(data)
 
 
-def full_type_name(value):
-    """
-    The full class name of a type or object.
-    """
-
-    if not isinstance(value, type):
-        value = value.__class__
-    module = str(value.__module__)
-    name = str(value.__name__)
-    return name if module == '__builtin__' else '%s.%s' % (module, name)
-
-
 def decode_list(data):
     decoded_list = []
     for item in data:
@@ -163,8 +151,8 @@ def as_raw(value):
             value = value()
     elif isinstance(value, list):
         value = list(value)
-        for i, _ in enumerate(value):
-            value[i] = as_raw(value[i])
+        for i, v in enumerate(value):
+            value[i] = as_raw(v)
     elif isinstance(value, dict):
         value = dict(value)
         for k, v in value.iteritems():

--- a/aria/utils/specification.py
+++ b/aria/utils/specification.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .collections import OrderedDict
+
+
+DSL_SPECIFICATIONS = {}
+
+
+def implements_specification(section, spec):
+    """
+    Decorator for specification implementations.
+
+    Used for documentation and standards compliance.
+    """
+
+    from .type import full_type_name
+
+    def decorator(obj):
+        specification = DSL_SPECIFICATIONS.get(spec)
+
+        if specification is None:
+            specification = {}
+            DSL_SPECIFICATIONS[spec] = specification
+
+        if section in specification:
+            raise Exception('you cannot specify the same @implements_specification twice, consider'
+                            ' adding \'-1\', \'-2\', etc.: {0}, {1}'.format(spec, section))
+
+        specification[section] = OrderedDict((
+            ('code', full_type_name(obj)),
+            ('doc', obj.__doc__)))
+
+        try:
+            setattr(obj, '_dsl_specifications', {section: section, spec: spec})
+        except BaseException:
+            pass
+
+        return obj
+
+    return decorator

--- a/aria/utils/type.py
+++ b/aria/utils/type.py
@@ -13,49 +13,142 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+
+from .specification import implements_specification
+
+
+BASE_TYPES_TO_CANONICAL_NAMES = {
+    # TOSCA aliases:
+    None.__class__: 'null',
+    basestring: 'string',
+    int: 'integer',
+    float: 'float',
+    bool: 'boolean',
+    list: 'list',
+    tuple: 'list',
+    dict: 'map',
+    datetime.datetime: 'timestamp'
+}
+
+NAMES_TO_CANONICAL_TYPES = {
+    # Python:
+    'none': None.__class__,
+    'basestring': unicode,
+    'str': unicode,
+    'unicode': unicode,
+    'int': int,
+    'float': float, # also a TOSCA alias
+    'bool': bool,
+    'list': list, # also a TOSCA alias
+    'tuple': list,
+    'dict': dict,
+    'datetime': datetime.datetime,
+
+    # YAML 1.2:
+    'tag:yaml.org,2002:null': None.__class__,
+    'tag:yaml.org,2002:str': unicode,
+    'tag:yaml.org,2002:integer': int,
+    'tag:yaml.org,2002:float': float,
+    'tag:yaml.org,2002:bool': bool,
+
+    # TOSCA aliases:
+    'null': None.__class__,
+    'string': unicode,
+    'integer': int,
+    'boolean': bool,
+
+    # TOSCA custom types:
+    'map': dict,
+    'timestamp': datetime.datetime
+}
+
+
+def full_type_name(value):
+    """
+    The full class name of a type or instance.
+    """
+
+    if not isinstance(value, type):
+        value = value.__class__
+    module = str(value.__module__)
+    name = str(value.__name__)
+    return name if module == '__builtin__' else '{0}.{1}'.format(module, name)
+
+
+@implements_specification('3.2.1-1', 'tosca-simple-1.0')
+def canonical_type_name(value):
+    """
+    Returns the canonical TOSCA type name of a primitive value, or None if unknown.
+
+    For a list of TOSCA type names, see the `TOSCA Simple Profile v1.0
+    cos01 specification <http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01
+    /TOSCA-Simple-Profile-YAML-v1.0-cos01.html#_Toc373867862>`__
+    """
+
+    for the_type, name in BASE_TYPES_TO_CANONICAL_NAMES.iteritems():
+        if isinstance(value, the_type):
+            return name
+    return None
+
+
+@implements_specification('3.2.1-2', 'tosca-simple-1.0')
+def canonical_type(type_name):
+    """
+    Return the canonical type for any Python, YAML, or TOSCA type name or alias, or None if
+    unsupported.
+
+    :param type_name: Type name (case insensitive)
+    """
+
+    return NAMES_TO_CANONICAL_TYPES.get(type_name.lower())
+
 
 def validate_value_type(value, type_name):
     """
-    Validate a value is of a specific type.
+    Validate that a value is of a specific type. Supports Python, YAML, and TOSCA type names and
+    aliases.
+
     A ValueError will be raised on type mismatch.
-    Supports both python and yaml type names.
+
+    :param type_name: Type name (case insensitive)
     """
 
-    #TODO add timestamp type?
-    name_to_type = {
-        'list': list,
-        'dict': dict,
-        'tuple': tuple,
-        'str': str,
-        'unicode': str,
-        'string': str,
-        'int': int,
-        'integer': int,
-        'bool': bool,
-        'boolean': bool,
-        'float': float
-    }
+    the_type = canonical_type(type_name)
+    if the_type is None:
+        raise RuntimeError('Unsupported type name: {0}'.format(type_name))
 
-    type_ = name_to_type.get(type_name.lower())
-    if type_ is None:
-        raise RuntimeError('No supported type_name was provided')
+    # The following Python types do not inherit from the canonical type, but are considered valid
+    if (the_type is unicode) and isinstance(value, str):
+        return
+    if (the_type is list) and isinstance(value, tuple):
+        return
 
-    if not isinstance(value, type_):
+    if not isinstance(value, the_type):
         raise ValueError('Value {0} is not of type {1}'.format(value, type_name))
 
 
-def convert_value_to_type(str_value, type_name):
+def convert_value_to_type(str_value, python_type_name):
+    """
+    Converts a value to a specific Python primitive type.
+
+    A ValueError will be raised for unsupported types or conversion failure.
+
+    :param python_type_name: Python primitive type name (case insensitive)
+    """
+
+    python_type_name = python_type_name.lower()
     try:
-        if type_name.lower() in ['str', 'unicode']:
+        if python_type_name in ('str', 'unicode'):
             return str_value.decode('utf-8')
-        elif type_name.lower() == 'int':
+        elif python_type_name == 'int':
             return int(str_value)
-        elif type_name.lower() == 'bool':
+        elif python_type_name == 'bool':
             return bool(str_value)
-        elif type_name.lower() == 'float':
+        elif python_type_name == 'float':
             return float(str_value)
         else:
-            raise ValueError('No supported type_name was provided')
+            raise ValueError('Unsupported Python type name: {0}'.format(python_type_name))
     except ValueError:
-        raise ValueError('Trying to convert {0} to {1} failed'.format(str_value,
-                                                                      type_name))
+        raise ValueError('Failed to to convert {0} to {1}'.format(str_value,
+                                                                  python_type_name))

--- a/examples/tosca-simple-1.0/use-cases/block-storage-1/block-storage-1.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-1/block-storage-1.yaml
@@ -65,4 +65,4 @@ topology_template:
       value: { get_attribute: [ my_server, private_address ] }
     volume_id:
       description: The volume id of the block storage instance.
-      value: { get_attribute: [ my_storage, volume_id ] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/block-storage-2/block-storage-2.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-2/block-storage-2.yaml
@@ -72,4 +72,4 @@ topology_template:
 
     volume_id:
       description: The volume id of the block storage instance.
-      value: { get_attribute: [ my_storage, volume_id ] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/block-storage-3/block-storage-3.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-3/block-storage-3.yaml
@@ -65,4 +65,4 @@ topology_template:
       value: { get_attribute: [ my_server, private_address ] }
     volume_id:
       description: The volume id of the block storage instance.
-      value: { get_attribute: [ my_storage, volume_id ] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/block-storage-4/block-storage-4.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-4/block-storage-4.yaml
@@ -93,4 +93,4 @@ topology_template:
       value: { get_attribute: [ my_web_app_tier_2, private_address ] }
     volume_id:
       description: The volume id of the block storage instance.
-      value: { get_attribute: [ my_storage, volume_id ] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/block-storage-5/block-storage-5.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-5/block-storage-5.yaml
@@ -100,10 +100,10 @@ topology_template:
   outputs:
     private_ip_1:
       description: The private IP address of the application's first tier.
-      value: { get_attribute: [my_web_app_tier_1, private_address] }
+      value: { get_attribute: [ my_web_app_tier_1, private_address ] }
     private_ip_2:
       description: The private IP address of the application's second tier.
-      value: { get_attribute: [my_web_app_tier_2, private_address] }
+      value: { get_attribute: [ my_web_app_tier_2, private_address ] }
     volume_id:
       description: The volume id of the block storage instance.
-      value: { get_attribute: [my_storage, volume_id] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/block-storage-6/block-storage-6.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-6/block-storage-6.yaml
@@ -96,7 +96,7 @@ topology_template:
       value: { get_attribute: [ my_server2, private_address ] }
     volume_id_1:
       description: The volume id of the first block storage instance.
-      value: { get_attribute: [my_storage, volume_id] }
+      value: { get_property: [ my_storage, volume_id ] } # ARIA NOTE: wrong in spec
     volume_id_2:
       description: The volume id of the second block storage instance.
-      value: { get_attribute: [ my_storage2, volume_id ] }
+      value: { get_property: [ my_storage2, volume_id ] } # ARIA NOTE: wrong in spec

--- a/examples/tosca-simple-1.0/use-cases/multi-tier-1/multi-tier-1.yaml
+++ b/examples/tosca-simple-1.0/use-cases/multi-tier-1/multi-tier-1.yaml
@@ -59,7 +59,7 @@ topology_template:
              implementation: scripts/nodejs/configure.sh
              inputs:
                github_url: { get_property: [ SELF, github_url ] }
-               mongodb_ip: { get_attribute: [mongo_server, private_address] }
+               mongodb_ip: { get_attribute: [ mongo_server, private_address ] }
            start: scripts/nodejs/start.sh
 
     nodejs:
@@ -90,7 +90,7 @@ topology_template:
           configure:
             implementation: scripts/mongodb/config.sh
             inputs:
-              mongodb_ip: { get_attribute: [mongo_server, ip_address] }
+              mongodb_ip: { get_attribute: [ mongo_server, private_address ] } # ARIA NOTE: wrong in spec
           start: scripts/mongodb/start.sh
 
     elasticsearch:
@@ -115,7 +115,7 @@ topology_template:
                   pre_configure_source:
                     implementation: python/logstash/configure_elasticsearch.py
                     inputs:
-                      elasticsearch_ip: { get_attribute: [elasticsearch_server, ip_address] }
+                      elasticsearch_ip: { get_attribute: [ elasticsearch_server, private_address ] } # ARIA NOTE: wrong in spec
       interfaces:
         Standard: # ARIA NOTE: wrong in spec
           create: scripts/lostash/create.sh
@@ -133,8 +133,8 @@ topology_template:
           configure:
             implementation: scripts/kibana/config.sh
             inputs:
-              elasticsearch_ip: { get_attribute: [ elasticsearch_server, ip_address ] }
-              kibana_ip: { get_attribute: [ kibana_server, ip_address ] }
+              elasticsearch_ip: { get_attribute: [ elasticsearch_server, private_address ] } # ARIA NOTE: wrong in spec
+              kibana_ip: { get_attribute: [ kibana_server, private_address ] } # ARIA NOTE: wrong in spec
           start: scripts/kibana/start.sh
 
     app_collectd:
@@ -155,7 +155,7 @@ topology_template:
           configure:
             implementation: python/collectd/config.py
             inputs:
-              logstash_ip: { get_attribute: [ logstash_server, ip_address ] }
+              logstash_ip: { get_attribute: [ logstash_server, private_address ] } # ARIA NOTE: wrong in spec
           start: scripts/collectd/start.sh
 
     app_rsyslog:
@@ -176,7 +176,7 @@ topology_template:
           configure:
             implementation: scripts/rsyslog/config.sh
             inputs:
-              logstash_ip: { get_attribute: [ logstash_server, ip_address ] }
+              logstash_ip: { get_attribute: [ logstash_server, private_address ] } # ARIA NOTE: wrong in spec
           start: scripts/rsyslog/start.sh
 
     app_server:

--- a/extensions/aria_extension_tosca/simple_v1_0/__init__.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/__init__.py
@@ -30,8 +30,6 @@ from .types import (ArtifactType, DataType, CapabilityType, InterfaceType, Relat
                     NodeType, GroupType, PolicyType)
 from .data_types import (Timestamp, Version, Range, List, Map, ScalarSize, ScalarTime,
                          ScalarFrequency)
-from .functions import (Concat, Token, GetInput, GetProperty, GetAttribute, GetOperationOutput,
-                        GetNodesOfType, GetArtifact)
 
 MODULES = (
     'modeling',
@@ -89,12 +87,4 @@ __all__ = (
     'Map',
     'ScalarSize',
     'ScalarTime',
-    'ScalarFrequency',
-    'Concat',
-    'Token',
-    'GetInput',
-    'GetProperty',
-    'GetAttribute',
-    'GetOperationOutput',
-    'GetNodesOfType',
-    'GetArtifact')
+    'ScalarFrequency')

--- a/extensions/aria_extension_tosca/simple_v1_0/assignments.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/assignments.py
@@ -15,7 +15,7 @@
 
 from aria.utils.collections import FrozenDict
 from aria.utils.caching import cachedmethod
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (AsIsPresentation, has_fields, allow_unknown_fields,
                                       short_form_field, primitive_field, object_field,
                                       object_dict_field, object_dict_unknown_fields,
@@ -32,7 +32,7 @@ from .presentation.field_validators import (node_template_or_type_validator,
 from .presentation.types import (convert_shorthand_to_full_type_name,
                                  get_type_by_full_or_shorthand_name)
 
-@dsl_specification('3.5.9', 'tosca-simple-1.0')
+@implements_specification('3.5.9', 'tosca-simple-1.0')
 class PropertyAssignment(AsIsPresentation):
     """
     This section defines the grammar for assigning values to named properties within TOSCA Node and
@@ -45,7 +45,7 @@ class PropertyAssignment(AsIsPresentation):
 
 @short_form_field('implementation')
 @has_fields
-@dsl_specification('3.5.13-2', 'tosca-simple-1.0')
+@implements_specification('3.5.13-2', 'tosca-simple-1.0')
 class OperationAssignment(ExtensiblePresentation):
     """
     An operation definition defines a named function or procedure that can be bound to an
@@ -105,7 +105,7 @@ class OperationAssignment(ExtensiblePresentation):
 
 @allow_unknown_fields
 @has_fields
-@dsl_specification('3.5.14-2', 'tosca-simple-1.0')
+@implements_specification('3.5.14-2', 'tosca-simple-1.0')
 class InterfaceAssignment(ExtensiblePresentation):
     """
     An interface definition defines a named interface that can be associated with a Node or
@@ -200,7 +200,7 @@ class RelationshipAssignment(ExtensiblePresentation):
 
 @short_form_field('node')
 @has_fields
-@dsl_specification('3.7.2', 'tosca-simple-1.0')
+@implements_specification('3.7.2', 'tosca-simple-1.0')
 class RequirementAssignment(ExtensiblePresentation):
     """
     A Requirement assignment allows template authors to provide either concrete names of TOSCA
@@ -297,7 +297,7 @@ class RequirementAssignment(ExtensiblePresentation):
 
         return None, None
 
-@dsl_specification('3.5.11', 'tosca-simple-1.0')
+@implements_specification('3.5.11', 'tosca-simple-1.0')
 class AttributeAssignment(AsIsPresentation):
     """
     This section defines the grammar for assigning values to named attributes within TOSCA Node and
@@ -309,7 +309,7 @@ class AttributeAssignment(AsIsPresentation):
     """
 
 @has_fields
-@dsl_specification('3.7.1', 'tosca-simple-1.0')
+@implements_specification('3.7.1', 'tosca-simple-1.0')
 class CapabilityAssignment(ExtensiblePresentation):
     """
     A capability assignment allows node template authors to assign values to properties and
@@ -351,7 +351,7 @@ class CapabilityAssignment(ExtensiblePresentation):
             if capability_definition is not None else None
 
 @has_fields
-@dsl_specification('3.5.6', 'tosca-simple-1.0')
+@implements_specification('3.5.6', 'tosca-simple-1.0')
 class ArtifactAssignment(ExtensiblePresentation):
     """
     An artifact definition defines a named, typed file that can be associated with Node Type or Node

--- a/extensions/aria_extension_tosca/simple_v1_0/data_types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/data_types.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from total_ordering import total_ordering
 
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.utils.collections import StrictDict, OrderedDict
 from aria.utils.formatting import safe_repr
 
@@ -51,7 +51,7 @@ class Timezone(tzinfo):
 UTC = Timezone()
 
 @total_ordering
-@dsl_specification('timestamp', 'yaml-1.1')
+@implements_specification('timestamp', 'yaml-1.1')
 class Timestamp(object):
     '''
     TOSCA timestamps follow the YAML specification, which in turn is a variant of ISO8601.
@@ -146,7 +146,7 @@ class Timestamp(object):
         return '{0:g}'.format(the_datetime.microsecond / 1000000.0).lstrip('0')
 
 @total_ordering
-@dsl_specification('3.2.2', 'tosca-simple-1.0')
+@implements_specification('3.2.2', 'tosca-simple-1.0')
 class Version(object):
     """
     TOSCA supports the concept of "reuse" of type definitions, as well as template definitions which
@@ -229,7 +229,7 @@ class Version(object):
                             return True
         return False
 
-@dsl_specification('3.2.3', 'tosca-simple-1.0')
+@implements_specification('3.2.3', 'tosca-simple-1.0')
 class Range(object):
     """
     The range type can be used to define numeric ranges with a lower and upper boundary. For
@@ -276,7 +276,7 @@ class Range(object):
     def as_raw(self):
         return list(self.value)
 
-@dsl_specification('3.2.4', 'tosca-simple-1.0')
+@implements_specification('3.2.4', 'tosca-simple-1.0')
 class List(list):
     """
     The list type allows for specifying multiple values for a parameter of property. For example, if
@@ -309,7 +309,7 @@ class List(list):
     def as_raw(self):
         return list(self)
 
-@dsl_specification('3.2.5', 'tosca-simple-1.0')
+@implements_specification('3.2.5', 'tosca-simple-1.0')
 class Map(StrictDict):
     """
     The map type allows for specifying multiple values for a parameter of property as a map. In
@@ -349,7 +349,7 @@ class Map(StrictDict):
         return OrderedDict(self)
 
 @total_ordering
-@dsl_specification('3.2.6', 'tosca-simple-1.0')
+@implements_specification('3.2.6', 'tosca-simple-1.0')
 class Scalar(object):
     """
     The scalar-unit type can be used to define scalar values along with a unit from the list of
@@ -416,7 +416,7 @@ class Scalar(object):
             value = self.TYPE(scalar) # pylint: disable=no-member
         return self.value < value
 
-@dsl_specification('3.2.6.4', 'tosca-simple-1.0')
+@implements_specification('3.2.6.4', 'tosca-simple-1.0')
 class ScalarSize(Scalar):
     """
     Integer scalar for counting bytes.
@@ -444,7 +444,7 @@ class ScalarSize(Scalar):
     TYPE = int
     UNIT = 'bytes'
 
-@dsl_specification('3.2.6.5', 'tosca-simple-1.0')
+@implements_specification('3.2.6.5', 'tosca-simple-1.0')
 class ScalarTime(Scalar):
     """
     Floating point scalar for counting seconds.
@@ -469,7 +469,7 @@ class ScalarTime(Scalar):
     TYPE = float
     UNIT = 'seconds'
 
-@dsl_specification('3.2.6.6', 'tosca-simple-1.0')
+@implements_specification('3.2.6.6', 'tosca-simple-1.0')
 class ScalarFrequency(Scalar):
     """
     Floating point scalar for counting cycles per second (Hz).

--- a/extensions/aria_extension_tosca/simple_v1_0/definitions.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/definitions.py
@@ -15,7 +15,7 @@
 
 from aria.utils.collections import FrozenDict
 from aria.utils.caching import cachedmethod
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (has_fields, short_form_field, allow_unknown_fields,
                                       primitive_field, primitive_list_field, object_field,
                                       object_list_field, object_dict_field,
@@ -35,7 +35,7 @@ from .modeling.interfaces import (get_and_override_input_definitions_from_type,
                                   get_and_override_operation_definitions_from_type)
 
 @has_fields
-@dsl_specification('3.5.8', 'tosca-simple-1.0')
+@implements_specification('3.5.8', 'tosca-simple-1.0')
 class PropertyDefinition(ExtensiblePresentation):
     """
     A property definition defines a named, typed value and related data that can be associated with
@@ -86,7 +86,7 @@ class PropertyDefinition(ExtensiblePresentation):
 
     @primitive_field(str, default='supported', allowed=('supported', 'unsupported', 'experimental',
                                                         'deprecated'))
-    @dsl_specification(section='3.5.8.3', spec='tosca-simple-1.0')
+    @implements_specification(section='3.5.8.3', spec='tosca-simple-1.0')
     def status(self):
         """
         The optional status of the property relative to the specification or implementation.
@@ -121,7 +121,7 @@ class PropertyDefinition(ExtensiblePresentation):
         return get_property_constraints(context, self)
 
 @has_fields
-@dsl_specification('3.5.10', 'tosca-simple-1.0')
+@implements_specification('3.5.10', 'tosca-simple-1.0')
 class AttributeDefinition(ExtensiblePresentation):
     """
     An attribute definition defines a named, typed value that can be associated with an entity
@@ -190,7 +190,7 @@ class AttributeDefinition(ExtensiblePresentation):
         return get_data_type(context, self, 'type')
 
 @has_fields
-@dsl_specification('3.5.12', 'tosca-simple-1.0')
+@implements_specification('3.5.12', 'tosca-simple-1.0')
 class ParameterDefinition(PropertyDefinition):
     """
     A parameter definition is essentially a TOSCA property definition; however, it also allows a
@@ -225,7 +225,7 @@ class ParameterDefinition(PropertyDefinition):
 
 @short_form_field('implementation')
 @has_fields
-@dsl_specification('3.5.13-1', 'tosca-simple-1.0')
+@implements_specification('3.5.13-1', 'tosca-simple-1.0')
 class OperationDefinition(ExtensiblePresentation):
     """
     An operation definition defines a named function or procedure that can be bound to an
@@ -266,7 +266,7 @@ class OperationDefinition(ExtensiblePresentation):
 
 @allow_unknown_fields
 @has_fields
-@dsl_specification('3.5.14-1', 'tosca-simple-1.0')
+@implements_specification('3.5.14-1', 'tosca-simple-1.0')
 class InterfaceDefinition(ExtensiblePresentation):
     """
     An interface definition defines a named interface that can be associated with a Node or
@@ -352,7 +352,7 @@ class RelationshipDefinition(ExtensiblePresentation):
 
 @short_form_field('capability')
 @has_fields
-@dsl_specification('3.6.2', 'tosca-simple-1.0')
+@implements_specification('3.6.2', 'tosca-simple-1.0')
 class RequirementDefinition(ExtensiblePresentation):
     """
     The Requirement definition describes a named requirement (dependencies) of a TOSCA Node Type or
@@ -418,7 +418,7 @@ class RequirementDefinition(ExtensiblePresentation):
 
 @short_form_field('type')
 @has_fields
-@dsl_specification('3.6.1', 'tosca-simple-1.0')
+@implements_specification('3.6.1', 'tosca-simple-1.0')
 class CapabilityDefinition(ExtensiblePresentation):
     """
     A capability definition defines a named, typed set of data that can be associated with Node Type

--- a/extensions/aria_extension_tosca/simple_v1_0/filters.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/filters.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from aria.utils.caching import cachedmethod
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (has_fields, object_sequenced_list_field, field_validator)
 
 from .misc import ConstraintClause
@@ -45,7 +45,7 @@ class CapabilityFilter(ExtensiblePresentation):
         return None
 
 @has_fields
-@dsl_specification('3.5.4', 'tosca-simple-1.0')
+@implements_specification('3.5.4', 'tosca-simple-1.0')
 class NodeFilter(ExtensiblePresentation):
     """
     A node filter definition defines criteria for selection of a TOSCA Node Template based upon the
@@ -58,7 +58,7 @@ class NodeFilter(ExtensiblePresentation):
 
     @field_validator(node_filter_properties_validator)
     @object_sequenced_list_field(ConstraintClause)
-    @dsl_specification('3.5.3', 'tosca-simple-1.0')
+    @implements_specification('3.5.3', 'tosca-simple-1.0')
     def properties(self):
         """
         An optional sequenced list of property filters that would be used to select (filter)

--- a/extensions/aria_extension_tosca/simple_v1_0/misc.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/misc.py
@@ -16,7 +16,7 @@
 from aria.utils.caching import cachedmethod
 from aria.utils.console import puts
 from aria.utils.formatting import as_raw
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (AsIsPresentation, has_fields, allow_unknown_fields,
                                       short_form_field, primitive_field, primitive_list_field,
                                       primitive_dict_unknown_fields, object_field,
@@ -36,7 +36,7 @@ from .presentation.field_validators import (constraint_clause_field_validator,
 from .presentation.types import (convert_shorthand_to_full_type_name,
                                  get_type_by_full_or_shorthand_name)
 
-@dsl_specification('3.5.1', 'tosca-simple-1.0')
+@implements_specification('3.5.1', 'tosca-simple-1.0')
 class Description(AsIsPresentation):
     """
     See the `TOSCA Simple Profile v1.0 cos01 specification <http://docs.oasis-open.org/tosca
@@ -53,10 +53,10 @@ class Description(AsIsPresentation):
 
 @allow_unknown_fields
 @has_fields
-@dsl_specification('3.9.3.2', 'tosca-simple-1.0')
+@implements_specification('3.9.3.2', 'tosca-simple-1.0')
 class MetaData(ExtensiblePresentation):
     @primitive_field(str)
-    @dsl_specification('3.9.3.3', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.3', 'tosca-simple-1.0')
     def template_name(self):
         """
         This optional metadata keyname can be used to declare the name of service template as a
@@ -64,7 +64,7 @@ class MetaData(ExtensiblePresentation):
         """
 
     @primitive_field(str)
-    @dsl_specification('3.9.3.4', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.4', 'tosca-simple-1.0')
     def template_author(self):
         """
         This optional metadata keyname can be used to declare the author(s) of the service template
@@ -72,7 +72,7 @@ class MetaData(ExtensiblePresentation):
         """
 
     @primitive_field(str)
-    @dsl_specification('3.9.3.5', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.5', 'tosca-simple-1.0')
     def template_version(self):
         """
         This optional metadata keyname can be used to declare a domain specific version of the
@@ -87,7 +87,7 @@ class MetaData(ExtensiblePresentation):
 
 @short_form_field('url')
 @has_fields
-@dsl_specification('3.5.5', 'tosca-simple-1.0')
+@implements_specification('3.5.5', 'tosca-simple-1.0')
 class Repository(ExtensiblePresentation):
     """
     A repository definition defines a named external repository which contains deployment and
@@ -128,7 +128,7 @@ class Repository(ExtensiblePresentation):
 
 @short_form_field('file')
 @has_fields
-@dsl_specification('3.5.7', 'tosca-simple-1.0')
+@implements_specification('3.5.7', 'tosca-simple-1.0')
 class Import(ExtensiblePresentation):
     """
     An import definition is used within a TOSCA Service Template to locate and uniquely name another
@@ -177,7 +177,7 @@ class Import(ExtensiblePresentation):
         """
 
 @has_fields
-@dsl_specification('3.5.2', 'tosca-simple-1.0')
+@implements_specification('3.5.2-1', 'tosca-simple-1.0')
 class ConstraintClause(ExtensiblePresentation):
     """
     A constraint clause defines an operation along with one or more compatible values that can be
@@ -376,7 +376,7 @@ class SubstitutionMappingsCapability(AsIsPresentation):
         validate_subtitution_mappings_capability(context, self)
 
 @has_fields
-@dsl_specification('2.10', 'tosca-simple-1.0')
+@implements_specification('2.10', 'tosca-simple-1.0')
 class SubstitutionMappings(ExtensiblePresentation):
     @field_validator(type_validator('node type', convert_shorthand_to_full_type_name, 'node_types'))
     @primitive_field(str, required=True)

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/constraints.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/constraints.py
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from aria.modeling.contraints import NodeTemplateConstraint
+from aria.modeling.utils import NodeTemplateContainerHolder
+from aria.modeling.functions import evaluate
+from aria.parser import implements_specification
+
+
+@implements_specification('3.5.2-2', 'tosca-simple-1.0')
+class EvaluatingNodeTemplateConstraint(NodeTemplateConstraint):
+    """
+    A version of :class:`NodeTemplateConstraint` with boilerplate initialization for TOSCA
+    constraints.
+    """
+
+    def __init__(self, property_name, capability_name, constraint, as_list=False):
+        self.property_name = property_name
+        self.capability_name = capability_name
+        self.constraint = constraint
+        self.as_list = as_list
+
+    def matches(self, source_node_template, target_node_template):
+        # TOSCA node template constraints can refer to either capability properties or node
+        # template properties
+        if self.capability_name is not None:
+            # Capability property
+            capability = target_node_template.capability_templates.get(self.capability_name)
+            value = capability.properties.get(self.property_name) \
+                if capability is not None else None # Parameter
+        else:
+            # Node template property
+            value = target_node_template.properties.get(self.property_name) # Parameter
+
+        value = value.value if value is not None else None
+
+        container_holder = NodeTemplateContainerHolder(source_node_template)
+
+        if self.as_list:
+            constraints = []
+            for constraint in self.constraint:
+                evaluation = evaluate(constraint, container_holder)
+                if evaluation is not None:
+                    constraints.append(evaluation.value)
+                else:
+                    constraints.append(constraint)
+            constraint = constraints
+        else:
+            evaluation = evaluate(self.constraint, container_holder)
+            if evaluation is not None:
+                constraint = evaluation.value
+            else:
+                constraint = self.constraint
+
+        return self.matches_evaluated(value, constraint)
+
+    def matches_evaluated(self, value, constraint):
+        raise NotImplementedError
+
+
+class Equal(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return value == constraint
+
+
+class GreaterThan(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return value > constraint
+
+
+class GreaterOrEqual(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return value >= constraint
+
+
+class LessThan(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return value < constraint
+
+
+class LessOrEqual(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return value <= constraint
+
+
+class InRange(EvaluatingNodeTemplateConstraint):
+    def __init__(self, property_name, capability_name, constraint):
+        super(InRange, self).__init__(property_name, capability_name, constraint, as_list=True)
+
+    def matches_evaluated(self, value, constraints):
+        lower, upper = constraints
+        if value < lower:
+            return False
+        if (upper != 'UNBOUNDED') and (value > upper):
+            return False
+        return True
+
+
+class ValidValues(EvaluatingNodeTemplateConstraint):
+    def __init__(self, property_name, capability_name, constraint):
+        super(ValidValues, self).__init__(property_name, capability_name, constraint, as_list=True)
+
+    def matches_evaluated(self, value, constraints):
+        return value in constraints
+
+
+class Length(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return len(value) == constraint
+
+
+class MinLength(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return len(value) >= constraint
+
+
+class MaxLength(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        return len(value) <= constraint
+
+
+class Pattern(EvaluatingNodeTemplateConstraint):
+    def matches_evaluated(self, value, constraint):
+        # From TOSCA 1.0 3.5.2.1:
+        #
+        # "Note: Future drafts of this specification will detail the use of regular expressions and
+        # reference an appropriate standardized grammar."
+        #
+        # So we will just use Python's.
+        return re.match(constraint, unicode(value)) is not None

--- a/extensions/aria_extension_tosca/simple_v1_0/presentation/field_validators.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/presentation/field_validators.py
@@ -16,7 +16,7 @@
 import re
 
 from aria.utils.formatting import safe_repr
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (report_issue_for_unknown_type, derived_from_validator)
 from aria.parser.validation import Issue
 
@@ -28,8 +28,7 @@ from .types import get_type_by_full_or_shorthand_name, convert_shorthand_to_full
 # NodeTemplate, RelationshipTemplate
 #
 
-@dsl_specification('3.7.3.3', 'tosca-simple-1.0')
-@dsl_specification('3.7.4.3', 'tosca-simple-1.0')
+@implements_specification('3.7.3.3', 'tosca-simple-1.0')
 def copy_validator(template_type_name, templates_dict_name):
     """
     Makes sure that the field refers to an existing template defined in the root presenter.
@@ -304,8 +303,12 @@ def constraint_clause_pattern_validator(field, presentation, context):
     value = getattr(presentation, field.name)
     if value is not None:
         try:
-            # Note: the TOSCA 1.0 spec does not specify the regular expression grammar, so we will
-            # just use Python's
+            # From TOSCA 1.0 3.5.2.1:
+            #
+            # "Note: Future drafts of this specification will detail the use of regular expressions
+            # and reference an appropriate standardized grammar."
+            #
+            # So we will just use Python's.
             re.compile(value)
         except re.error as e:
             context.validation.report(

--- a/extensions/aria_extension_tosca/simple_v1_0/presenter.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/presenter.py
@@ -17,9 +17,9 @@ from aria.utils.collections import FrozenList, EMPTY_READ_ONLY_LIST
 from aria.utils.caching import cachedmethod
 from aria.parser.presentation import Presenter
 
-from .functions import (Concat, Token, GetInput, GetProperty, GetAttribute, GetOperationOutput,
-                        GetNodesOfType, GetArtifact)
 from .modeling import create_service_template_model
+from .modeling.functions import (Concat, Token, GetInput, GetProperty, GetAttribute,
+                                 GetOperationOutput, GetNodesOfType, GetArtifact)
 from .templates import ServiceTemplate
 
 class ToscaSimplePresenter1_0(Presenter): # pylint: disable=invalid-name,abstract-method

--- a/extensions/aria_extension_tosca/simple_v1_0/templates.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/templates.py
@@ -15,7 +15,7 @@
 
 from aria.utils.collections import FrozenDict, FrozenList
 from aria.utils.caching import cachedmethod
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (has_fields, primitive_field, primitive_list_field,
                                       object_field, object_list_field, object_dict_field,
                                       object_sequenced_list_field, field_validator,
@@ -26,7 +26,7 @@ from .assignments import (PropertyAssignment, AttributeAssignment, RequirementAs
 from .definitions import ParameterDefinition
 from .filters import NodeFilter
 from .misc import (Description, MetaData, Repository, Import, SubstitutionMappings)
-from .modeling.properties import get_assigned_and_defined_property_values, get_parameter_values
+from .modeling.properties import (get_assigned_and_defined_property_values, get_parameter_values)
 from .modeling.interfaces import get_template_interfaces
 from .modeling.requirements import get_template_requirements
 from .modeling.capabilities import get_template_capabilities
@@ -41,7 +41,7 @@ from .types import (ArtifactType, DataType, CapabilityType, InterfaceType, Relat
                     NodeType, GroupType, PolicyType)
 
 @has_fields
-@dsl_specification('3.7.3', 'tosca-simple-1.0')
+@implements_specification('3.7.3', 'tosca-simple-1.0')
 class NodeTemplate(ExtensiblePresentation):
     """
     A Node Template specifies the occurrence of a manageable software component as part of an
@@ -160,6 +160,11 @@ class NodeTemplate(ExtensiblePresentation):
         return FrozenDict(get_assigned_and_defined_property_values(context, self))
 
     @cachedmethod
+    def _get_attribute_default_values(self, context):
+        return FrozenDict(get_assigned_and_defined_property_values(context, self,
+                                                                   'attribute', 'attributes'))
+
+    @cachedmethod
     def _get_requirements(self, context):
         return FrozenList(get_template_requirements(context, self))
 
@@ -198,7 +203,7 @@ class NodeTemplate(ExtensiblePresentation):
             'copy'))
 
 @has_fields
-@dsl_specification('3.7.4', 'tosca-simple-1.0')
+@implements_specification('3.7.4', 'tosca-simple-1.0')
 class RelationshipTemplate(ExtensiblePresentation):
     """
     A Relationship Template specifies the occurrence of a manageable relationship between node
@@ -297,7 +302,7 @@ class RelationshipTemplate(ExtensiblePresentation):
             'copy'))
 
 @has_fields
-@dsl_specification('3.7.5', 'tosca-simple-1.0')
+@implements_specification('3.7.5', 'tosca-simple-1.0')
 class GroupTemplate(ExtensiblePresentation):
     """
     A group definition defines a logical grouping of node templates, typically for management
@@ -370,7 +375,7 @@ class GroupTemplate(ExtensiblePresentation):
         self._get_interfaces(context)
 
 @has_fields
-@dsl_specification('3.7.6', 'tosca-simple-1.0')
+@implements_specification('3.7.6', 'tosca-simple-1.0')
 class PolicyTemplate(ExtensiblePresentation):
     """
     A policy definition defines a policy that can be associated with a TOSCA topology or top-level
@@ -434,7 +439,7 @@ class PolicyTemplate(ExtensiblePresentation):
         self._get_property_values(context)
 
 @has_fields
-@dsl_specification('3.8', 'tosca-simple-1.0')
+@implements_specification('3.8', 'tosca-simple-1.0')
 class TopologyTemplate(ExtensiblePresentation):
     """
     This section defines the topology template of a cloud application. The main ingredients of the
@@ -544,7 +549,7 @@ class TopologyTemplate(ExtensiblePresentation):
             'substitution_mappings'))
 
 @has_fields
-@dsl_specification('3.9', 'tosca-simple-1.0')
+@implements_specification('3.9', 'tosca-simple-1.0')
 class ServiceTemplate(ExtensiblePresentation):
     """
     See the `TOSCA Simple Profile v1.0 cos01 specification <http://docs.oasis-open.org/tosca
@@ -553,7 +558,7 @@ class ServiceTemplate(ExtensiblePresentation):
     """
 
     @primitive_field(str)
-    @dsl_specification('3.9.3.1', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.1', 'tosca-simple-1.0')
     def tosca_definitions_version(self):
         """
         Defines the version of the TOSCA Simple Profile specification the template (grammar)
@@ -580,7 +585,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_field(Description)
-    @dsl_specification('3.9.3.6', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.6', 'tosca-simple-1.0')
     def description(self):
         """
         Declares a description for this Service Template and its contents.
@@ -589,7 +594,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @primitive_field()
-    @dsl_specification('3.9.3.7', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.7', 'tosca-simple-1.0')
     def dsl_definitions(self):
         """
         Declares optional DSL-specific definitions and conventions. For example, in YAML, this
@@ -602,7 +607,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(Repository)
-    @dsl_specification('3.9.3.8', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.8', 'tosca-simple-1.0')
     def repositories(self):
         """
         Declares the list of external repositories which contain artifacts that are referenced in
@@ -613,7 +618,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_list_field(Import)
-    @dsl_specification('3.9.3.9', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.9', 'tosca-simple-1.0')
     def imports(self):
         """
         Declares import statements external TOSCA Definitions documents. For example, these may be
@@ -623,7 +628,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(ArtifactType)
-    @dsl_specification('3.9.3.10', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.10', 'tosca-simple-1.0')
     def artifact_types(self):
         """
         This section contains an optional list of artifact type definitions for use in the service
@@ -633,7 +638,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(DataType)
-    @dsl_specification('3.9.3.11', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.11', 'tosca-simple-1.0')
     def data_types(self):
         """
         Declares a list of optional TOSCA Data Type definitions.
@@ -642,7 +647,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(CapabilityType)
-    @dsl_specification('3.9.3.12', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.12', 'tosca-simple-1.0')
     def capability_types(self):
         """
         This section contains an optional list of capability type definitions for use in the service
@@ -652,7 +657,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(InterfaceType)
-    @dsl_specification('3.9.3.13', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.13', 'tosca-simple-1.0')
     def interface_types(self):
         """
         This section contains an optional list of interface type definitions for use in the service
@@ -662,7 +667,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(RelationshipType)
-    @dsl_specification('3.9.3.14', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.14', 'tosca-simple-1.0')
     def relationship_types(self):
         """
         This section contains a set of relationship type definitions for use in the service
@@ -672,7 +677,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(NodeType)
-    @dsl_specification('3.9.3.15', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.15', 'tosca-simple-1.0')
     def node_types(self):
         """
         This section contains a set of node type definitions for use in the service template.
@@ -681,7 +686,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(GroupType)
-    @dsl_specification('3.9.3.16', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.16', 'tosca-simple-1.0')
     def group_types(self):
         """
         This section contains a list of group type definitions for use in the service template.
@@ -690,7 +695,7 @@ class ServiceTemplate(ExtensiblePresentation):
         """
 
     @object_dict_field(PolicyType)
-    @dsl_specification('3.9.3.17', 'tosca-simple-1.0')
+    @implements_specification('3.9.3.17', 'tosca-simple-1.0')
     def policy_types(self):
         """
         This section contains a list of policy type definitions for use in the service template.

--- a/extensions/aria_extension_tosca/simple_v1_0/types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/types.py
@@ -15,7 +15,7 @@
 
 from aria.utils.collections import FrozenDict, FrozenList
 from aria.utils.caching import cachedmethod
-from aria.parser import dsl_specification
+from aria.parser import implements_specification
 from aria.parser.presentation import (has_fields, allow_unknown_fields, primitive_field,
                                       primitive_list_field, object_field, object_dict_field,
                                       object_list_field, object_sequenced_list_field,
@@ -46,7 +46,7 @@ from .presentation.field_validators import (data_type_derived_from_validator,
 from .presentation.types import convert_shorthand_to_full_type_name
 
 @has_fields
-@dsl_specification('3.6.3', 'tosca-simple-1.0')
+@implements_specification('3.6.3', 'tosca-simple-1.0')
 class ArtifactType(ExtensiblePresentation):
     """
     An Artifact Type is a reusable entity that defines the type of one or more files that are used
@@ -131,7 +131,7 @@ class ArtifactType(ExtensiblePresentation):
             'properties'))
 
 @has_fields
-@dsl_specification('3.6.5', 'tosca-simple-1.0')
+@implements_specification('3.6.5', 'tosca-simple-1.0')
 class DataType(ExtensiblePresentation):
     """
     A Data Type definition defines the schema for new named datatypes in TOSCA.
@@ -225,7 +225,7 @@ class DataType(ExtensiblePresentation):
             'properties'))
 
 @has_fields
-@dsl_specification('3.6.6', 'tosca-simple-1.0')
+@implements_specification('3.6.6', 'tosca-simple-1.0')
 class CapabilityType(ExtensiblePresentation):
     """
     A Capability Type is a reusable entity that describes a kind of capability that a Node Type can
@@ -328,7 +328,7 @@ class CapabilityType(ExtensiblePresentation):
 
 @allow_unknown_fields
 @has_fields
-@dsl_specification('3.6.4', 'tosca-simple-1.0')
+@implements_specification('3.6.4', 'tosca-simple-1.0')
 class InterfaceType(ExtensiblePresentation):
     """
     An Interface Type is a reusable entity that describes a set of operations that can be used to
@@ -406,7 +406,7 @@ class InterfaceType(ExtensiblePresentation):
             'operations'))
 
 @has_fields
-@dsl_specification('3.6.9', 'tosca-simple-1.0')
+@implements_specification('3.6.9', 'tosca-simple-1.0')
 class RelationshipType(ExtensiblePresentation):
     """
     A Relationship Type is a reusable entity that defines the type of one or more relationships
@@ -520,7 +520,7 @@ class RelationshipType(ExtensiblePresentation):
             'interfaces'))
 
 @has_fields
-@dsl_specification('3.6.8', 'tosca-simple-1.0')
+@implements_specification('3.6.8', 'tosca-simple-1.0')
 class NodeType(ExtensiblePresentation):
     """
     A Node Type is a reusable entity that defines the type of one or more Node Templates. As such, a
@@ -668,7 +668,7 @@ class NodeType(ExtensiblePresentation):
             'capabilities'))
 
 @has_fields
-@dsl_specification('3.6.10', 'tosca-simple-1.0')
+@implements_specification('3.6.10', 'tosca-simple-1.0')
 class GroupType(ExtensiblePresentation):
     """
     A Group Type defines logical grouping types for nodes, typically for different management
@@ -781,7 +781,7 @@ class GroupType(ExtensiblePresentation):
             'interfaces'))
 
 @has_fields
-@dsl_specification('3.6.11', 'tosca-simple-1.0')
+@implements_specification('3.6.11', 'tosca-simple-1.0')
 class PolicyType(ExtensiblePresentation):
     """
     A Policy Type defines a type of requirement that affects or governs an application or service's

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
@@ -33,6 +33,7 @@ imports:
   - types/mongodb.yaml
   - types/nginx.yaml
   - aria-1.0
+
 dsl_definitions:
 
   default_openstack_credential: &DEFAULT_OPENSTACK_CREDENTIAL
@@ -94,8 +95,11 @@ topology_template:
           properties:
             unpack_credential:
               user: gigaspaces
-              token: { get_property: [ SELF, app_endpoint, protocol ] }
+              token: { get_attribute: [ SELF, tosca_id ] }
+              #token: { get_property: [ SELF, app_endpoint, protocol ] }
               #token: { get_property: [ HOST, flavor_name ] }
+              #token: { token: [ { get_property: [ HOST, flavor_name ] }, '.', 1 ] }
+              #token: { token: [ 'zero.one|two-three', '.|-', 3 ] }
       interfaces:
         Maintenance:
           enable: juju > charm.maintenance_on


### PR DESCRIPTION
Areas this PR addresses:

- Refactored TOSCA functions
- Refactored `Parameter` model to use a property for `value`, and similar for `coerce_values`
- Added utility properties to `Parameter` model: `container`, `service`, and `service_template`
- New in `modeling.functions`: `evaluate` function, `Evaluation` return value, `NodeTemplateConstraints` class
- Re-enabled and fixed node filter constraints handling in modeling to support new evaluation system
- Re-enabled value coercion for service instances in CLI core
- Fix back population for one-to-one relationships
- Fixes to TOSCA use case examples
