### PR TITLE
ARIA-157 Failing CLI service-templates store tests on Windows

### DIFF
--- a/tests/cli/test_service_templates.py
+++ b/tests/cli/test_service_templates.py
@@ -128,6 +128,7 @@ class TestServiceTemplatesStore(TestCliBase):
 
         monkeypatch.setattr(Core, 'create_service_template', mock_object)
         monkeypatch.setattr(service_template_utils, 'get', mock_object)
+        monkeypatch.setattr(os.path, 'dirname', mock_object)
         self.invoke('service_templates store stubpath {name}'.format(
             name=mock_models.SERVICE_TEMPLATE_NAME))
         assert 'Service template {name} stored'.format(
@@ -152,6 +153,7 @@ class TestServiceTemplatesStore(TestCliBase):
                             'create_service_template',
                             raise_exception(storage_exceptions.NotFoundError,
                                             msg='UNIQUE constraint failed'))
+        monkeypatch.setattr(os.path, 'dirname', mock_object)
 
         assert_exception_raised(
             self.invoke('service_templates store stubpath test_st'),
@@ -164,6 +166,7 @@ class TestServiceTemplatesStore(TestCliBase):
         monkeypatch.setattr(Core,
                             'create_service_template',
                             raise_exception(storage_exceptions.NotFoundError))
+        monkeypatch.setattr(os.path, 'dirname', mock_object)
 
         assert_exception_raised(
             self.invoke('service_templates store stubpath test_st'),


### PR DESCRIPTION
Three tests from `aria service-templates store` failed on Windows, but
not on Linux.

The reason for this failures was differing implementation of
os.path.dirname across the platforms.

Python implements os.path.dirname in the ntpath module. There, somewhere
down the line of calls, (a part of) the argument of dirname is tested
for membership in a string (using `in`). In these three tests, the
argument of dirname is of type MagicMock, and an error is raised since
only a string can be tested for membership in a string.

The solution was to mock the dirname calls.