### PR TITLE
ARIA-171 service_template.services type inconsistency

### DIFF
--- a/aria/cli/commands/service_templates.py
+++ b/aria/cli/commands/service_templates.py
@@ -89,8 +89,8 @@ def show(service_template_name, model_storage, mode_full, mode_types, format_jso
 
         if service_template.services:
             logger.info('Existing services:')
-            for service in service_template.services:
-                logger.info('\t{0}'.format(service.name))
+            for service_name in service_template.services:
+                logger.info('\t{0}'.format(service_name))
 
 
 @service_templates.command(name='list',

--- a/aria/modeling/service_template.py
+++ b/aria/modeling/service_template.py
@@ -208,7 +208,7 @@ class ServiceTemplateBase(TemplateModelMixin):
 
     @declared_attr
     def services(cls):
-        return relationship.one_to_many(cls, 'service')
+        return relationship.one_to_many(cls, 'service', dict_key='name')
 
     @declared_attr
     def operation_templates(cls):

--- a/tests/cli/test_service_templates.py
+++ b/tests/cli/test_service_templates.py
@@ -65,7 +65,8 @@ class TestServiceTemplatesShow(TestCliBase):
 
         monkeypatch.setattr(_Environment, 'model_storage', mock_storage)
         st = mock_models.create_service_template()
-        st.services = [mock_models.create_service(st)]
+        s = mock_models.create_service(st)
+        st.services = {s.name: s}
         monkeypatch.setattr(mock_storage.service_template, 'get_by_name',
                             mock.MagicMock(return_value=st))
 
@@ -79,7 +80,8 @@ class TestServiceTemplatesShow(TestCliBase):
 
         monkeypatch.setattr(_Environment, 'model_storage', mock_storage)
         st = mock_models.create_service_template(description='test_description')
-        st.services = [mock_models.create_service(st)]
+        s = mock_models.create_service(st)
+        st.services = {s.name: s}
         monkeypatch.setattr(mock_storage.service_template, 'get_by_name',
                             mock.MagicMock(return_value=st))
 

--- a/tests/end2end/test_hello_world.py
+++ b/tests/end2end/test_hello_world.py
@@ -52,7 +52,7 @@ def _verify_deployed_service_in_storage(service_name, model_storage):
     service_templates = model_storage.service_template.list()
     assert len(service_templates) == 1
     assert len(service_templates[0].services) == 1
-    service = service_templates[0].services[0]
+    service = service_templates[0].services[service_name]
     assert service.name == service_name
     assert len(service.executions) == 1
     assert len(service.nodes) == 2

--- a/tests/end2end/test_nodecellar.py
+++ b/tests/end2end/test_nodecellar.py
@@ -36,7 +36,7 @@ def _verify_deployed_service_in_storage(service_name, model_storage):
     service_templates = model_storage.service_template.list()
     assert len(service_templates) == 1
     assert len(service_templates[0].services) == 1
-    service = service_templates[0].services[0]
+    service = service_templates[0].services[service_name]
     assert service.name == service_name
     assert len(service.executions) == 0  # dry executions leave no traces
     assert len(service.nodes) == 10


### PR DESCRIPTION
As opposed to service_template.node_templates and service.nodes
which have a dict interface, service_template.services
had a list interface. That seemed as inconsistent, so the former
interface was changed to a dict interface as well.