### PR TITLE
ARIA-162 Upgrade Colorama library version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ wagon==0.6.0
 bottle>=0.12.0, <0.13
 Fabric>=1.13.0, <1.14
 click>=4.1, < 5.0
-colorama>=0.3.3, < 0.3.5
+colorama>=0.3.7, <= 0.3.9
 PrettyTable>=0.7,<0.8
 click_didyoumean==0.0.3
 backports.shutil_get_terminal_size==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ cffi==1.10.0              # via cryptography
 click==4.1
 click_didyoumean==0.0.3
 clint==0.5.1
-colorama==0.3.4
+colorama==0.3.9
 cryptography==1.8.1       # via paramiko
 decorator==4.0.11         # via networkx
 enum34==1.1.6             # via cryptography
@@ -57,6 +57,3 @@ six==1.10.0               # via cryptography, packaging, retrying
 sqlalchemy==1.1.6
 wagon==0.6.0
 wheel==0.29.0             # via wagon
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools                # via cryptography


### PR DESCRIPTION
Upgraded the Colorama library version - This should
take care of the closed-stream error that appeared
sporadically after test runs.