### PR TITLE
ARIA-280 Change package name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,10 +36,10 @@ To install ARIA directly from PyPI (using a ``wheel``), use::
     pip install apache-ariatosca
 
 To install ARIA from source, download the source tarball from
-`PyPI <https://pypi.python.org/pypi/apache-ariatosca>`__, extract it, and run::
+`PyPI <https://pypi.python.org/pypi/apache-ariatosca>`__, extract and ``cd`` into the extract dir, and run::
 
     pip install --upgrade pip setuptools
-    pip install incubator-ariatosca
+    pip install .
 
 | The source package comes along with relevant examples, documentation, ``requirements.txt`` (for installing specifically the frozen dependencies' versions with which ARIA was tested) and more.
 |

--- a/aria/__init__.py
+++ b/aria/__init__.py
@@ -20,10 +20,11 @@ ARIA top level package
 import sys
 
 import pkg_resources
-__version__ = pkg_resources.get_distribution('aria').version
+aria_package_name = 'apache-ariatosca'
+__version__ = pkg_resources.get_distribution(aria_package_name).version
 
-from .orchestrator.decorators import workflow, operation
-from . import (
+from .orchestrator.decorators import workflow, operation  # pylint: disable=wrong-import-position
+from . import (  # pylint: disable=wrong-import-position
     extension,
     utils,
     parser,

--- a/aria/cli/core/aria.py
+++ b/aria/cli/core/aria.py
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import os
 import sys
 import difflib
-import StringIO
 import traceback
 import inspect
 from functools import wraps
@@ -32,6 +30,7 @@ from .. import defaults
 from .. import helptexts
 from ..inputs import inputs_to_dict
 from ... import __version__
+from ... import aria_package_name
 from ...utils.exceptions import get_exception_as_string
 
 
@@ -94,31 +93,11 @@ def mutually_exclusive_option(*param_decls, **attrs):
     return decorator
 
 
-def _format_version_data(version,
-                         prefix=None,
-                         suffix=None,
-                         infix=None):
-    all_data = dict(version=version)
-    all_data['prefix'] = prefix or ''
-    all_data['suffix'] = suffix or ''
-    all_data['infix'] = infix or ''
-    output = StringIO.StringIO()
-    output.write('{prefix}{version}'.format(**all_data))
-    output.write('{suffix}'.format(**all_data))
-    return output.getvalue()
-
-
 def show_version(ctx, param, value):
     if not value:
         return
 
-    cli_version = _format_version_data(
-        __version__,
-        prefix='ARIA CLI ',
-        infix=' ' * 5,
-        suffix='')
-
-    logger.info(cli_version)
+    logger.info('{0} {1}'.format(aria_package_name, __version__))
     ctx.exit()
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools.command.install import install
 from setuptools.command.develop import develop
 
 
-_PACKAGE_NAME = 'aria'
+_PACKAGE_NAME = 'apache-ariatosca'
 _PYTHON_SUPPORTED_VERSIONS = [(2, 6), (2, 7)]
 _EXTENSION_DIR = 'extensions'
 _EXTENSION_NAMES = [
@@ -38,6 +38,7 @@ root_dir = os.path.dirname(__file__)
 
 with open(os.path.join(root_dir, 'VERSION')) as version_file:
     __version__ = version_file.read().strip()
+    incubating_version = '{0}-incubating'.format(__version__)
 
 with open(os.path.join(root_dir, 'README.rst')) as readme:
     long_description = readme.read()
@@ -106,11 +107,11 @@ setup(
     description='ARIA',
     long_description=long_description,
     license='Apache License 2.0',
-    author='aria',
+    author='ARIA',
     author_email='dev@ariatosca.incubator.apache.org',
     url='http://ariatosca.incubator.apache.org/',
     download_url=(
-        'https://dist.apache.org/repos/dist/release/incubator/ariatosca/' + __version__),
+        'https://dist.apache.org/repos/dist/release/incubator/ariatosca/' + incubating_version),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
Changed package name from 'aria' to 'apache-ariatosca',
in accordance with Apache's standards.