### PR TITLE
ARIA-290 Update Makefile for binary dist creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ test:
 
 dist: docs
 	python ./setup.py sdist bdist_wheel
+	# pushing LICENSE and additional files into the binary distribution archive
+	-find "$(DIST)" -type f -name '*.whl' -exec zip -u {} LICENSE NOTICE DISCLAIMER \;
 
 deploy:
 	pip install --upgrade "twine>=1.9.1"


### PR DESCRIPTION
Updated the Makefile to push required files for release
(LICENSE, NOTICE, DISCLAIMER) into the binary distribution
archive (wheel) automatically.