### PR TITLE
ARIA-287 Add tox environment for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,16 @@ install-virtual:
 docs:
 	pip install --requirement "$(DOCS)/requirements.txt"
 	rm -rf "$(HTML)"
-	sphinx-build -b html "$(DOCS)" "$(HTML)"
+	sphinx-build -W -T -b html "$(DOCS)" "$(HTML)"
 
 test:
 	pip install --upgrade "tox>=2.7.0"
-	tox -e pylint_code -e pylint_tests -e py$(PYTHON_VERSION) -e py$(PYTHON_VERSION)e2e -e py$(PYTHON_VERSION)ssh
+	tox -e pylint_code \
+	    -e pylint_tests \
+	    -e py$(PYTHON_VERSION) \
+	    -e py$(PYTHON_VERSION)e2e \
+	    -e py$(PYTHON_VERSION)ssh \
+	    -e docs
 
 dist: docs
 	python ./setup.py sdist bdist_wheel

--- a/tox.ini
+++ b/tox.ini
@@ -11,18 +11,19 @@
 # limitations under the License.
 
 [tox]
-envlist=py27,py26,py27e2e,py26e2e,pywin,py27ssh,pylint_code,pylint_tests
+envlist=py27,py26,py27e2e,py26e2e,pywin,py27ssh,pylint_code,pylint_tests,docs
 
 [testenv]
-passenv =
-    TRAVIS
-    PYTHON
-    PYTHON_VERSION
-    PYTHON_ARCH
-deps =
-    -rrequirements.txt
-    -rtests/requirements.txt
-basepython =
+whitelist_externals=rm
+passenv=
+  TRAVIS
+  PYTHON
+  PYTHON_VERSION
+  PYTHON_ARCH
+deps=
+  -rrequirements.txt
+  -rtests/requirements.txt
+basepython=
   py26: python2.6
   py27: python2.7
   py26e2e: python2.6
@@ -32,6 +33,7 @@ basepython =
   pywin: {env:PYTHON:}\python.exe
   pylint_code: python2.7
   pylint_tests: python2.7
+  docs: python2.7
 
 [testenv:py27]
 commands=pytest tests --ignore=tests/end2end --ignore=tests/orchestrator/execution_plugin/test_ssh.py --cov-report term-missing --cov aria
@@ -61,3 +63,9 @@ commands=pylint --rcfile=aria/.pylintrc --disable=fixme,missing-docstring aria e
 
 [testenv:pylint_tests]
 commands=pylint --rcfile=tests/.pylintrc --disable=fixme,missing-docstring tests
+
+[testenv:docs]
+commands=
+  pip install --requirement docs/requirements.txt
+  rm --recursive --force docs/html
+  sphinx-build -W -T -b html docs docs/html


### PR DESCRIPTION
Also adds the environment to "make test". Involves fixing Sphinx to
properly exclude SSH documentation when Fabric is not installed.