### PR TITLE
ARIA-313 Fix handling the `required` field of inputs

### DIFF
--- a/aria/modeling/exceptions.py
+++ b/aria/modeling/exceptions.py
@@ -45,7 +45,7 @@ class CannotEvaluateFunctionException(ModelingException):
     """
 
 
-class MissingRequiredParametersException(ParameterException):
+class MissingRequiredInputsException(ParameterException):
     """
     ARIA modeling exception: Required parameters have been omitted.
     """
@@ -57,7 +57,7 @@ class ParametersOfWrongTypeException(ParameterException):
     """
 
 
-class UndeclaredParametersException(ParameterException):
+class UndeclaredInputsException(ParameterException):
     """
     ARIA modeling exception: Undeclared parameters have been provided.
     """

--- a/aria/modeling/mixins.py
+++ b/aria/modeling/mixins.py
@@ -161,8 +161,6 @@ class ParameterMixin(TemplateModelMixin, caching.HasCachedMethods):             
     :func:`~aria.modeling.functions.evaluate`.
     """
 
-    __tablename__ = 'parameter'
-
     type_name = Column(Text, doc="""
     Type name.
     

--- a/aria/modeling/service_common.py
+++ b/aria/modeling/service_common.py
@@ -22,6 +22,7 @@ ARIA modeling service common module
 from sqlalchemy import (
     Column,
     Text,
+    Boolean
 )
 from sqlalchemy.ext.declarative import declared_attr
 
@@ -83,6 +84,18 @@ class InputBase(ParameterMixin):
     """
 
     __tablename__ = 'input'
+
+    required = Column(Boolean, doc="""
+    Is the input mandatory.
+
+    :type: :obj:`bool`
+    """)
+
+    @classmethod
+    def wrap(cls, name, value, description=None, required=True):  # pylint: disable=arguments-differ
+        input = super(InputBase, cls).wrap(name, value, description)
+        input.required = required
+        return input
 
     # region many_to_one relationships
 

--- a/aria/modeling/service_instance.py
+++ b/aria/modeling/service_instance.py
@@ -1939,7 +1939,7 @@ class OperationBase(InstanceModelMixin):
     """)
 
     retry_interval = Column(Integer, doc="""
-    Interval between task retry attemps (in seconds).
+    Interval between task retry attempts (in seconds).
 
     :type: :obj:`float`
     """)

--- a/aria/modeling/service_template.py
+++ b/aria/modeling/service_template.py
@@ -343,6 +343,11 @@ class ServiceTemplateBase(TemplateModelMixin):
         context = ConsumptionContext.get_thread_local()
         context.modeling.instance = service
 
+        utils.validate_no_undeclared_inputs(declared_inputs=self.inputs,
+                                            supplied_inputs=inputs or {})
+        utils.validate_required_inputs_are_supplied(declared_inputs=self.inputs,
+                                                    supplied_inputs=inputs or {})
+
         service.inputs = utils.merge_parameter_values(inputs, self.inputs, model_cls=models.Input)
         # TODO: now that we have inputs, we should scan properties and inputs and evaluate functions
 

--- a/aria/orchestrator/workflow_runner.py
+++ b/aria/orchestrator/workflow_runner.py
@@ -137,6 +137,10 @@ class WorkflowRunner(object):
         else:
             workflow_inputs = self.service.workflows[self._workflow_name].inputs
 
+        modeling_utils.validate_no_undeclared_inputs(declared_inputs=workflow_inputs,
+                                                     supplied_inputs=inputs or {})
+        modeling_utils.validate_required_inputs_are_supplied(declared_inputs=workflow_inputs,
+                                                             supplied_inputs=inputs or {})
         execution.inputs = modeling_utils.merge_parameter_values(inputs,
                                                                  workflow_inputs,
                                                                  model_cls=models.Input)

--- a/aria/parser/consumption/style.py
+++ b/aria/parser/consumption/style.py
@@ -48,3 +48,7 @@ class Style(object):
     @staticmethod
     def meta(value):
         return Colored.green(value)
+
+    @staticmethod
+    def required(value):
+        return Colored.white(value)

--- a/aria/parser/presentation/presentation.py
+++ b/aria/parser/presentation/presentation.py
@@ -29,10 +29,11 @@ class Value(object):
     Encapsulates a typed value assignment.
     """
 
-    def __init__(self, type_name, value, description):
+    def __init__(self, type_name, value, description, required):
         self.type = deepcopy_with_locators(type_name)
         self.value = deepcopy_with_locators(value)
         self.description = deepcopy_with_locators(description)
+        self.required = deepcopy_with_locators(required)
 
     def _dump(self, context):
         if self.type is not None:
@@ -41,6 +42,8 @@ class Value(object):
             puts(context.style.literal(self.value))
         if self.description is not None:
             puts(context.style.meta(self.description))
+        if self.required is not None:
+            puts(context.style.required(self.required))
 
 
 class PresentationBase(HasCachedMethods):

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/data_types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/data_types.py
@@ -438,10 +438,7 @@ def coerce_to_primitive(context, presentation, primitive_type, constraints, valu
 
         # Check constraints
         apply_constraints_to_value(context, presentation, constraints, value)
-    except ValueError as e:
-        report_issue_for_bad_format(context, presentation, primitive_type, value, aspect, e)
-        value = None
-    except TypeError as e:
+    except (ValueError, TypeError) as e:
         report_issue_for_bad_format(context, presentation, primitive_type, value, aspect, e)
         value = None
 

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/interfaces.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/interfaces.py
@@ -61,7 +61,7 @@ def get_and_override_input_definitions_from_type(context, presentation):
     inputs = OrderedDict()
 
     # Get inputs from type
-    the_type = presentation._get_type(context) # IntefaceType
+    the_type = presentation._get_type(context) # InterfaceType
     type_inputs = the_type._get_inputs(context) if the_type is not None else None
     if type_inputs:
         for input_name, type_input in type_inputs.iteritems():
@@ -213,9 +213,9 @@ def convert_interface_definition_from_type_to_raw_template(context, presentation
     raw = OrderedDict()
 
     # Copy default values for inputs
-    inputs = presentation._get_inputs(context)
-    if inputs is not None:
-        raw['inputs'] = convert_parameter_definitions_to_values(context, inputs)
+    interface_inputs = presentation._get_inputs(context)
+    if interface_inputs is not None:
+        raw['inputs'] = convert_parameter_definitions_to_values(context, interface_inputs)
 
     # Copy operations
     operations = presentation._get_operations(context)
@@ -481,6 +481,10 @@ def assign_raw_inputs(context, values, assignments, definitions, interface_name,
 
 def validate_required_inputs(context, presentation, assignment, definition, original_assignment,
                              interface_name, operation_name=None):
+    # The validation of the `required` field of inputs that belong to operations and interfaces
+    # (as opposed to topology template and workflow inputs) is done only in the parsing stage.
+    # This reasoning follows the TOSCA spirit, where anything that is declared as required in the
+    # type, must be assigned in the corresponding template.
     input_definitions = definition.inputs
     if input_definitions:
         for input_name, input_definition in input_definitions.iteritems():

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/parameters.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/parameters.py
@@ -203,7 +203,8 @@ def coerce_parameter_value(context, presentation, definition, value, aspect=None
         type_name = getattr(definition, 'type', None)
     description = getattr(definition, 'description', None)
     description = description.value if description is not None else None
-    return Value(type_name, value, description)
+    required = getattr(definition, 'required', None)
+    return Value(type_name, value, description, required)
 
 
 def convert_parameter_definitions_to_values(context, definitions):

--- a/tests/orchestrator/test_workflow_runner.py
+++ b/tests/orchestrator/test_workflow_runner.py
@@ -216,7 +216,7 @@ def test_execution_inputs_override_workflow_inputs(request):
 def test_execution_inputs_undeclared_inputs(request):
     mock_workflow = _setup_mock_workflow_in_service(request)
 
-    with pytest.raises(modeling_exceptions.UndeclaredParametersException):
+    with pytest.raises(modeling_exceptions.UndeclaredInputsException):
         _create_workflow_runner(request, mock_workflow, inputs={'undeclared_input': 'value'})
 
 
@@ -224,7 +224,7 @@ def test_execution_inputs_missing_required_inputs(request):
     mock_workflow = _setup_mock_workflow_in_service(
         request, inputs={'required_input': models.Input.wrap('required_input', value=None)})
 
-    with pytest.raises(modeling_exceptions.MissingRequiredParametersException):
+    with pytest.raises(modeling_exceptions.MissingRequiredInputsException):
         _create_workflow_runner(request, mock_workflow, inputs={})
 
 
@@ -238,7 +238,7 @@ def test_execution_inputs_wrong_type_inputs(request):
 
 def test_execution_inputs_builtin_workflow_with_inputs(request):
     # built-in workflows don't have inputs
-    with pytest.raises(modeling_exceptions.UndeclaredParametersException):
+    with pytest.raises(modeling_exceptions.UndeclaredInputsException):
         _create_workflow_runner(request, 'install', inputs={'undeclared_input': 'value'})
 
 
@@ -276,8 +276,8 @@ def service(model):
 def _setup_mock_workflow_in_service(request, inputs=None):
     # sets up a mock workflow as part of the service, including uploading
     # the workflow code to the service's dir on the resource storage
-    service = request.getfuncargvalue('service')
-    resource = request.getfuncargvalue('resource')
+    service = request.getfixturevalue('service')
+    resource = request.getfixturevalue('resource')
 
     source = tests_mock.workflow.__file__
     resource.service_template.upload(str(service.service_template.id), source)
@@ -299,10 +299,10 @@ def _setup_mock_workflow_in_service(request, inputs=None):
 def _create_workflow_runner(request, workflow_name, inputs=None, executor=None,
                             task_max_attempts=None, task_retry_interval=None):
     # helper method for instantiating a workflow runner
-    service_id = request.getfuncargvalue('service').id
-    model = request.getfuncargvalue('model')
-    resource = request.getfuncargvalue('resource')
-    plugin_manager = request.getfuncargvalue('plugin_manager')
+    service_id = request.getfixturevalue('service').id
+    model = request.getfixturevalue('model')
+    resource = request.getfixturevalue('resource')
+    plugin_manager = request.getfixturevalue('plugin_manager')
 
     # task configuration parameters can't be set to None, therefore only
     # passing those if they've been set by the test


### PR DESCRIPTION
The required field is handled in the following way:

topology_template inputs:
-------------------------
Every input that is declared as required must be supplied a value while
creating the service.
In addition, supplying inputs that were not declared in the topology
template is forbidden.

workflow inputs:*
----------------
Every input that is declared as required must be supplied a value while
creating/starting the execution.
In addition, supplying inputs that were not declared in the policy_type
is forbidden.
* workflow inputs are defined as properties of policy_types that are
derived from aria.Workflow

operation and interface inputs:
-------------------------------
The validation of the required field of inputs that belong to
operations and interfaces is done only in the parsing stage.
This reasoning follows the TOSCA spirit, where anything that is declared
as required in the type, must be assigned in the corresponding template

I split the logic of merging provided and declared input values into
three steps:

1. Validate that no undeclared inputs were provided.
2. Validate that all required inputs were provided with a value.
3. The actual merging process, which includes type checking.