### PR TITLE
ARIA-324 Refactor ctx proxy access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ sudo: false
 language: python
 
 python:
-  - "2.7"
+  - '2.7'
 
 env:
   - TOX_ENV=pylint_code

--- a/aria/orchestrator/context/common.py
+++ b/aria/orchestrator/context/common.py
@@ -38,10 +38,27 @@ class BaseContext(object):
     """
 
     INSTRUMENTATION_FIELDS = (
+        modeling.models.Service.inputs,
+        modeling.models.ServiceTemplate.inputs,
+        modeling.models.Policy.properties,
+        modeling.models.PolicyTemplate.properties,
         modeling.models.Node.attributes,
         modeling.models.Node.properties,
         modeling.models.NodeTemplate.attributes,
-        modeling.models.NodeTemplate.properties
+        modeling.models.NodeTemplate.properties,
+        modeling.models.Group.properties,
+        modeling.models.GroupTemplate.properties,
+        modeling.models.Capability.properties,
+        # TODO ARIA-279: modeling.models.Capability.attributes,
+        modeling.models.CapabilityTemplate.properties,
+        # TODO ARIA-279: modeling.models.CapabilityTemplate.attributes
+        modeling.models.Relationship.properties,
+        modeling.models.Artifact.properties,
+        modeling.models.ArtifactTemplate.properties,
+        modeling.models.Interface.inputs,
+        modeling.models.InterfaceTemplate.inputs,
+        modeling.models.Operation.inputs,
+        modeling.models.OperationTemplate.inputs
     )
 
     class PrefixedLogger(object):

--- a/aria/orchestrator/context/operation.py
+++ b/aria/orchestrator/context/operation.py
@@ -48,8 +48,7 @@ class BaseOperationContext(common.BaseContext):
     @property
     def task(self):
         """
-        The task in the model storage
-        :return: Task model
+        The task in the model storage.
         """
         # SQLAlchemy prevents from accessing an object which was created on a different thread.
         # So we retrieve the object from the storage if the current thread isn't the same as the
@@ -62,7 +61,7 @@ class BaseOperationContext(common.BaseContext):
     @property
     def plugin_workdir(self):
         """
-        A work directory that is unique to the plugin and the deployment id
+        A work directory that is unique to the plugin and the service ID.
         """
         if self.task.plugin is None:
             return None
@@ -120,20 +119,18 @@ class NodeOperationContext(BaseOperationContext):
     """
 
     @property
-    def node_template(self):
-        """
-        the node of the current operation
-        :return:
-        """
-        return self.node.node_template
-
-    @property
     def node(self):
         """
-        The node instance of the current operation
-        :return:
+        The node of the current operation.
         """
         return self.model.node.get(self._actor_id)
+
+    @property
+    def node_template(self):
+        """
+        The node template of the current operation.
+        """
+        return self.node.node_template
 
 
 class RelationshipOperationContext(BaseOperationContext):
@@ -142,41 +139,36 @@ class RelationshipOperationContext(BaseOperationContext):
     """
 
     @property
-    def source_node_template(self):
+    def relationship(self):
         """
-        The source node
-        :return:
+        The relationship instance of the current operation.
         """
-        return self.source_node.node_template
+        return self.model.relationship.get(self._actor_id)
 
     @property
     def source_node(self):
         """
-        The source node instance
-        :return:
+        The relationship source node.
         """
         return self.relationship.source_node
 
     @property
-    def target_node_template(self):
+    def source_node_template(self):
         """
-        The target node
-        :return:
+        The relationship source node template.
         """
-        return self.target_node.node_template
+        return self.source_node.node_template
 
     @property
     def target_node(self):
         """
-        The target node instance
-        :return:
+        The relationship target node.
         """
         return self.relationship.target_node
 
     @property
-    def relationship(self):
+    def target_node_template(self):
         """
-        The relationship instance of the current operation
-        :return:
+        The relationship target node template.
         """
-        return self.model.relationship.get(self._actor_id)
+        return self.target_node.node_template

--- a/aria/orchestrator/execution_plugin/ctx_proxy/client.py
+++ b/aria/orchestrator/execution_plugin/ctx_proxy/client.py
@@ -102,9 +102,12 @@ def main(args=None):
     if args.json_output:
         response = json.dumps(response)
     else:
-        if not response:
+        if response is None:
             response = ''
-        response = str(response)
+        try:
+            response = str(response)
+        except UnicodeEncodeError:
+            response = unicode(response).encode('utf8')
     sys.stdout.write(response)
 
 if __name__ == '__main__':

--- a/aria/orchestrator/workflows/api/task.py
+++ b/aria/orchestrator/workflows/api/task.py
@@ -140,13 +140,18 @@ class OperationTask(BaseTask):
         self.arguments = modeling_utils.merge_parameter_values(arguments,
                                                                operation.arguments,
                                                                model_cls=models.Argument)
-        if getattr(self.actor, 'outbound_relationships', None) is not None:
+
+        actor = self.actor
+        if hasattr(actor, '_wrapped'):
+            # Unwrap instrumented model
+            actor = actor._wrapped
+        if isinstance(actor, models.Node):
             self._context_cls = context.operation.NodeOperationContext
-        elif getattr(self.actor, 'source_node', None) is not None:
+        elif isinstance(actor, models.Relationship):
             self._context_cls = context.operation.RelationshipOperationContext
         else:
-            raise exceptions.TaskCreationException('Could not locate valid context for '
-                                                   '{actor.__class__}'.format(actor=self.actor))
+            raise exceptions.TaskCreationException('Could not create valid context for '
+                                                   '{actor.__class__}'.format(actor=actor))
 
     def __repr__(self):
         return self.name

--- a/aria/storage/core.py
+++ b/aria/storage/core.py
@@ -130,7 +130,7 @@ class ModelStorage(Storage):
         """
         model_name = model_cls.__modelname__
         if model_name in self.registered:
-            self.logger.debug('{name} in already storage {self!r}'.format(name=model_name,
+            self.logger.debug('{name} already in storage {self!r}'.format(name=model_name,
                                                                           self=self))
             return
         self.registered[model_name] = self.api(name=model_name,
@@ -151,10 +151,10 @@ class ModelStorage(Storage):
         original_instrumentation = {}
 
         try:
-            for mapi in self.registered.values():
+            for mapi in self.registered.itervalues():
                 original_instrumentation[mapi] = copy.copy(mapi._instrumentation)
                 mapi._instrumentation.extend(instrumentation)
             yield self
         finally:
-            for mapi in self.registered.values():
+            for mapi in self.registered.itervalues():
                 mapi._instrumentation[:] = original_instrumentation[mapi]

--- a/examples/hello-world/scripts/configure.sh
+++ b/examples/hello-world/scripts/configure.sh
@@ -16,22 +16,21 @@
 
 set -e
 
-TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
-if [ -d ${PYTHON_FILE_SERVER_ROOT} ]; then
-	echo "Removing file server root folder ${PYTHON_FILE_SERVER_ROOT}"
-	rm -rf ${PYTHON_FILE_SERVER_ROOT}
+TEMP_DIR=/tmp
+PYTHON_FILE_SERVER_ROOT="$TEMP_DIR/python-simple-http-webserver"
+INDEX_PATH=index.html
+IMAGE_PATH=images/aria-logo.png
+
+if [ -d "$PYTHON_FILE_SERVER_ROOT" ]; then
+	ctx logger info [ "Removing old web server root folder: $PYTHON_FILE_SERVER_ROOT." ]
+	rm -rf "$PYTHON_FILE_SERVER_ROOT"
 fi
-ctx logger info "Creating HTTP server root directory at ${PYTHON_FILE_SERVER_ROOT}"
 
-mkdir -p ${PYTHON_FILE_SERVER_ROOT}
+ctx logger info [ "Creating web server root folder: $PYTHON_FILE_SERVER_ROOT." ]
 
-cd ${PYTHON_FILE_SERVER_ROOT}
+mkdir -p "$PYTHON_FILE_SERVER_ROOT"
+cd "$PYTHON_FILE_SERVER_ROOT"
 
-index_path="index.html"
-image_path="images/aria-logo.png"
-
-ctx logger info "Downloading blueprint resources..."
-ctx download-resource-and-render ${PYTHON_FILE_SERVER_ROOT}/index.html ${index_path}
-ctx download-resource ${PYTHON_FILE_SERVER_ROOT}/aria-logo.png ${image_path}
-
+ctx logger info [ "Downloading service template resources..." ]
+ctx download-resource-and-render [ "$PYTHON_FILE_SERVER_ROOT/index.html" "$INDEX_PATH" ]
+ctx download-resource [ "$PYTHON_FILE_SERVER_ROOT/aria-logo.png" "$IMAGE_PATH" ]

--- a/examples/hello-world/scripts/start.sh
+++ b/examples/hello-world/scripts/start.sh
@@ -16,51 +16,49 @@
 
 set -e
 
-TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
-PID_FILE="server.pid"
+TEMP_DIR=/tmp
+PYTHON_FILE_SERVER_ROOT="$TEMP_DIR/python-simple-http-webserver"
+PID_FILE=server.pid
+PORT=$(ctx node properties port)
+URL="http://localhost:$PORT"
 
-ctx logger info "Starting HTTP server from ${PYTHON_FILE_SERVER_ROOT}"
+ctx logger info [ "Starting web server at: $PYTHON_FILE_SERVER_ROOT." ]
 
-port=$(ctx node properties port)
-
-cd ${PYTHON_FILE_SERVER_ROOT}
-ctx logger info "Starting SimpleHTTPServer"
-nohup python -m SimpleHTTPServer ${port} > /dev/null 2>&1 &
-echo $! > ${PID_FILE}
-
-ctx logger info "Waiting for server to launch on port ${port}"
-url="http://localhost:${port}"
+cd "$PYTHON_FILE_SERVER_ROOT"
+nohup python -m SimpleHTTPServer "$PORT" > /dev/null 2>&1 &
+echo $! > "$PID_FILE"
 
 server_is_up() {
 	if which wget >/dev/null; then
-		if wget $url >/dev/null; then
+		if wget "$URL" >/dev/null; then
 			return 0
 		fi
 	elif which curl >/dev/null; then
-		if curl $url >/dev/null; then
+		if curl "$URL" >/dev/null; then
 			return 0
 		fi
 	else
-		ctx logger error "Both curl, wget were not found in path"
+		ctx logger error [ "Both curl and wget were not found in path." ]
 		exit 1
 	fi
 	return 1
 }
 
+ctx logger info [ "Waiting for web server to launch on port $PORT..." ]
 STARTED=false
 for i in $(seq 1 15)
 do
 	if server_is_up; then
-		ctx logger info "Server is up."
+		ctx logger info [ "Web server is up." ]
 		STARTED=true
     	break
 	else
-		ctx logger info "Server not up. waiting 1 second."
+		ctx logger info [ "Web server not up. waiting 1 second." ]
 		sleep 1
 	fi
 done
-if [ ${STARTED} = false ]; then
-	ctx logger error "Failed starting web server in 15 seconds."
+
+if [ "$STARTED" = false ]; then
+	ctx logger error [ "Web server did not start within 15 seconds." ]
 	exit 1
 fi

--- a/examples/hello-world/scripts/stop.sh
+++ b/examples/hello-world/scripts/stop.sh
@@ -16,14 +16,13 @@
 
 set -e
 
-TEMP_DIR="/tmp"
-PYTHON_FILE_SERVER_ROOT=${TEMP_DIR}/python-simple-http-webserver
-PID_FILE="server.pid"
+TEMP_DIR=/tmp
+PYTHON_FILE_SERVER_ROOT="${TEMP_DIR}/python-simple-http-webserver"
+PID_FILE=server.pid
+PID=$(cat "$PYTHON_FILE_SERVER_ROOT/$PID_FILE")
 
-PID=`cat ${PYTHON_FILE_SERVER_ROOT}/${PID_FILE}`
+ctx logger info [ "Shutting down web server, pid = ${PID}." ]
+kill -9 "$PID" || exit $?
 
-ctx logger info "Shutting down file server. pid = ${PID}"
-kill -9 ${PID} || exit $?
-
-ctx logger info "Deleting file server root directory (${PYTHON_FILE_SERVER_ROOT})"
-rm -rf ${PYTHON_FILE_SERVER_ROOT}
+ctx logger info [ "Removing web server root folder: $PYTHON_FILE_SERVER_ROOT." ]
+rm -rf "$PYTHON_FILE_SERVER_ROOT"

--- a/tests/orchestrator/execution_plugin/test_local.py
+++ b/tests/orchestrator/execution_plugin/test_local.py
@@ -43,10 +43,10 @@ class TestLocalRunScript(object):
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes map.key value
+            ctx node attributes map key = value
             ''',
             windows_script='''
-            ctx node attributes map.key value
+            ctx node attributes map key = value
         ''')
         props = self._run(
             executor, workflow_context,
@@ -57,12 +57,12 @@ class TestLocalRunScript(object):
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes map.key1 $key1
-            ctx node attributes map.key2 $key2
+            ctx node attributes map key1 = "$key1"
+            ctx node attributes map key2 = "$key2"
             ''',
             windows_script='''
-            ctx node attributes map.key1 %key1%
-            ctx node attributes map.key2 %key2%
+            ctx node attributes map key1 = %key1%
+            ctx node attributes map key2 = %key2%
         ''')
         props = self._run(
             executor, workflow_context,
@@ -81,10 +81,10 @@ class TestLocalRunScript(object):
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes map.cwd $PWD
+            ctx node attributes map cwd = "$PWD"
             ''',
             windows_script='''
-            ctx node attributes map.cwd %CD%
+            ctx node attributes map cwd = %CD%
             ''')
         tmpdir = str(tmpdir)
         props = self._run(
@@ -97,7 +97,7 @@ class TestLocalRunScript(object):
         assert p_map['cwd'] == tmpdir
 
     def test_process_command_prefix(self, executor, workflow_context, tmpdir):
-        use_ctx = 'ctx node attributes map.key value'
+        use_ctx = 'ctx node attributes map key = value'
         python_script = ['import subprocess',
                          'subprocess.Popen("{0}".split(' ')).communicate()[0]'.format(use_ctx)]
         python_script = '\n'.join(python_script)
@@ -121,12 +121,12 @@ class TestLocalRunScript(object):
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes map.arg1 "$1"
-            ctx node attributes map.arg2 $2
+            ctx node attributes map arg1 = "$1"
+            ctx node attributes map arg2 = "$2"
             ''',
             windows_script='''
-            ctx node attributes map.arg1 %1
-            ctx node attributes map.arg2 %2
+            ctx node attributes map arg1 = %1
+            ctx node attributes map arg2 = %2
             ''')
         props = self._run(
             executor, workflow_context,
@@ -149,12 +149,12 @@ class TestLocalRunScript(object):
             tmpdir,
             linux_script='''#! /bin/bash -e
             echo 123123
-            command_that_does_not_exist
+            command_that_does_not_exist [ ]
             ''',
             windows_script='''
             @echo off
             echo 123123
-            command_that_does_not_exist
+            command_that_does_not_exist [ ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -209,10 +209,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes key "${input_as_env_var}"
+            ctx node attributes key = "${input_as_env_var}"
             ''',
             windows_script='''
-            ctx node attributes key "%input_as_env_var%"
+            ctx node attributes key = "%input_as_env_var%"
         ''')
         props = self._run(
             executor, workflow_context,
@@ -228,10 +228,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx node attributes key "${input_as_env_var}"
+            ctx node attributes key = "${input_as_env_var}"
             ''',
             windows_script='''
-            ctx node attributes key "%input_as_env_var%"
+            ctx node attributes key = "%input_as_env_var%"
         ''')
 
         props = self._run(
@@ -268,10 +268,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx -j instance attributes nonexistent
+            ctx -j node attributes nonexistent
             ''',
             windows_script='''
-            ctx -j instance attributes nonexistent
+            ctx -j node attributes nonexistent
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -285,10 +285,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx task abort abort-message
+            ctx task abort [ abort-message ]
             ''',
             windows_script='''
-            ctx task abort abort-message
+            ctx task abort [ abort-message ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -300,10 +300,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx task retry retry-message
+            ctx task retry [ retry-message ]
             ''',
             windows_script='''
-            ctx task retry retry-message
+            ctx task retry [ retry-message ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -315,10 +315,10 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx task retry retry-message @100
+            ctx task retry [ retry-message @100 ]
             ''',
             windows_script='''
-            ctx task retry retry-message @100
+            ctx task retry [ retry-message @100 ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -331,12 +331,12 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash
-            ctx task retry retry-message
-            ctx task abort should-raise-a-runtime-error
+            ctx task retry [ retry-message ]
+            ctx task abort [ should-raise-a-runtime-error ]
             ''',
             windows_script='''
-            ctx task retry retry-message
-            ctx task abort should-raise-a-runtime-error
+            ctx task retry [ retry-message ]
+            ctx task abort [ should-raise-a-runtime-error ]
         ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -348,12 +348,12 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash
-            ctx task abort abort-message
-            ctx task retry should-raise-a-runtime-error
+            ctx task abort [ abort-message ]
+            ctx task retry [ should-raise-a-runtime-error ]
             ''',
             windows_script='''
-            ctx task abort abort-message
-            ctx task retry should-raise-a-runtime-error
+            ctx task abort [ abort-message ]
+            ctx task retry [ should-raise-a-runtime-error ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -365,12 +365,12 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash
-            ctx task abort abort-message
-            ctx task abort should-raise-a-runtime-error
+            ctx task abort [ abort-message ]
+            ctx task abort [ should-raise-a-runtime-error ]
             ''',
             windows_script='''
-            ctx task abort abort-message
-            ctx task abort should-raise-a-runtime-error
+            ctx task abort [ abort-message ]
+            ctx task abort [ should-raise-a-runtime-error ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -382,12 +382,12 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash
-            ctx task retry retry-message
-            ctx task retry should-raise-a-runtime-error
+            ctx task retry [ retry-message ]
+            ctx task retry [ should-raise-a-runtime-error ]
             ''',
             windows_script='''
-            ctx task retry retry-message
-            ctx task retry should-raise-a-runtime-error
+            ctx task retry [ retry-message ]
+            ctx task retry [ should-raise-a-runtime-error ]
             ''')
         exception = self._run_and_get_task_exception(
             executor, workflow_context,
@@ -401,11 +401,11 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx task retry '{0}' 2> {1}
+            ctx task retry [ "{0}" ] 2> {1}
             echo should-not-run > {1}
             '''.format(message, log_path),
             windows_script='''
-            ctx task retry "{0}" 2> {1}
+            ctx task retry [ "{0}" ] 2> {1}
             if %errorlevel% neq 0 exit /b %errorlevel%
             echo should-not-run > {1}
             '''.format(message, log_path))
@@ -421,11 +421,11 @@ if __name__ == '__main__':
         script_path = self._create_script(
             tmpdir,
             linux_script='''#! /bin/bash -e
-            ctx task abort '{0}' 2> {1}
+            ctx task abort [ "{0}" ] 2> {1}
             echo should-not-run > {1}
             '''.format(message, log_path),
             windows_script='''
-            ctx task abort "{0}" 2> {1}
+            ctx task abort [ "{0}" ] 2> {1}
             if %errorlevel% neq 0 exit /b %errorlevel%
             echo should-not-run > {1}
             '''.format(message, log_path))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -16,7 +16,7 @@ sh==1.12.14
 psutil==5.2.2
 mock==2.0.0
 pylint==1.6.5
-pytest==3.1.3
+pytest==3.2.0
 pytest-cov==2.5.1
-pytest-mock==1.6.0
-pytest-xdist==1.18.1
+pytest-mock==1.6.2
+pytest-xdist==1.18.2

--- a/tests/resources/scripts/test_ssh.sh
+++ b/tests/resources/scripts/test_ssh.sh
@@ -19,7 +19,7 @@ set -u
 set -e
 
 test_run_script_basic() {
-    ctx node attributes test_value $test_value
+    ctx node attributes test_value = "$test_value"
 }
 
 test_run_script_as_sudo() {
@@ -27,7 +27,7 @@ test_run_script_as_sudo() {
 }
 
 test_run_script_default_base_dir() {
-    ctx node attributes work_dir $PWD
+    ctx node attributes work_dir = "$PWD"
 }
 
 test_run_script_with_hide() {
@@ -35,44 +35,44 @@ test_run_script_with_hide() {
 }
 
 test_run_script_process_config() {
-    ctx node attributes env_value $test_value_env
-    ctx node attributes bash_version $BASH_VERSION
-    ctx node attributes arg1_value $1
-    ctx node attributes arg2_value $2
-    ctx node attributes cwd $PWD
-    ctx node attributes ctx_path $(which ctx)
+    ctx node attributes env_value = "$test_value_env"
+    ctx node attributes bash_version = "$BASH_VERSION"
+    ctx node attributes arg1_value = "$1"
+    ctx node attributes arg2_value = "$2"
+    ctx node attributes cwd = "$PWD"
+    ctx node attributes ctx_path = "$(which ctx)"
 }
 
 test_run_script_command_prefix() {
-    ctx node attributes dollar_dash $-
+    ctx node attributes dollar_dash = $-
 }
 
 test_run_script_reuse_existing_ctx_1() {
-    ctx node attributes test_value1 $test_value1
+    ctx node attributes test_value1 = "$test_value1"
 }
 
 test_run_script_reuse_existing_ctx_2() {
-    ctx node attributes test_value2 $test_value2
+    ctx node attributes test_value2 = "$test_value2"
 }
 
 test_run_script_download_resource_plain() {
-    local destination=$(mktemp)
-    ctx download-resource ${destination} test_resource
-    ctx node attributes test_value "$(cat ${destination})"
+    local DESTINATION=$(mktemp)
+    ctx download-resource [ "$DESTINATION" test_resource ]
+    ctx node attributes test_value = "$(cat "$DESTINATION")"
 }
 
 test_run_script_download_resource_and_render() {
-    local destination=$(mktemp)
-    ctx download-resource-and-render ${destination} test_resource
-    ctx node attributes test_value "$(cat ${destination})"
+    local DESTINATION=$(mktemp)
+    ctx download-resource-and-render [ "$DESTINATION" test_resource ]
+    ctx node attributes test_value = "$(cat "$DESTINATION")"
 }
 
 test_run_script_inputs_as_env_variables_no_override() {
-    ctx node attributes test_value "$custom_env_var"
+    ctx node attributes test_value = "$custom_env_var"
 }
 
 test_run_script_inputs_as_env_variables_process_env_override() {
-    ctx node attributes test_value "$custom_env_var"
+    ctx node attributes test_value = "$custom_env_var"
 }
 
 test_run_script_error_in_script() {
@@ -80,17 +80,17 @@ test_run_script_error_in_script() {
 }
 
 test_run_script_abort_immediate() {
-    ctx task abort abort-message
+    ctx task abort [ abort-message ]
 }
 
 test_run_script_retry() {
-    ctx task retry retry-message
+    ctx task retry [ retry-message ]
 }
 
 test_run_script_abort_error_ignored_by_script() {
     set +e
-    ctx task abort abort-message
+    ctx task abort [ abort-message ]
 }
 
 # Injected by test
-${test_operation} $@
+"$test_operation" "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -97,14 +97,14 @@ commands=
 [testenv:pylint_code]
 commands=
   pylint aria extensions/aria_extension_tosca/ \
-  --rcfile=aria/.pylintrc \
-  --disable=fixme,missing-docstring
+    --rcfile=aria/.pylintrc \
+    --disable=fixme,missing-docstring
 
 [testenv:pylint_tests]
 commands=
   pylint tests \
-  --rcfile=tests/.pylintrc \
-  --disable=fixme,missing-docstring
+    --rcfile=tests/.pylintrc \
+    --disable=fixme,missing-docstring
 
 [testenv:docs]
 install_command=


### PR DESCRIPTION
Our previous use of "." to delimit nested dict keys was wrong (keys
could have a ".") and inflexible. The new implementation uses subsequent
args to move into the dict.

The same format can now be used to access object attributes.

This commit also changes how to support setting values: we must now use
"=" as the penultimate argument with the new value following.

Also fixed: callables will now "grab" the number of args they need
instead of all remaining args, making it possible to do further
inspection on the returned value from the callable. To allow for this,
kwargs are now expected as the first arg rather than the last.

Furthmore, this commit fixes a bad null check in the ctx client, and
also allows it to retrieve Unicode data.