### PR TITLE
ARIA-321 Provide Clearwater IMS example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sudo: false
+# We need to set "sudo: true" in order to use a virtual machine instead of a container, because
+# SSH tests fail in the container. See:
+# https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments
+
+dist: trusty
+sudo: true
 
 language: python
 
-dist: precise
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:fkrull/deadsnakes'
+    packages:
+      # Ubuntu 14.04 (trusty) does not come with Python 2.6, so we will install it from Felix
+      # Krull's PPA
+      - python2.6
+      - python2.6-dev
+
 python:
+  # We handle Python 2.6 testing from within tox (see tox.ini); note that this means that we run
+  # tox itself always from Python 2.7
   - '2.7'
 
 env:
-  - TOX_ENV=pylint_code
-  - TOX_ENV=pylint_tests
-  - TOX_ENV=py27
-  - TOX_ENV=py26
-  - TOX_ENV=py27e2e
-  - TOX_ENV=py26e2e
-  - TOX_ENV=py27ssh
-  - TOX_ENV=py26ssh
-  - TOX_ENV=docs
+  # The PYTEST_PROCESSES environment var is used in tox.ini to override the --numprocesses argument
+  # for PyTest's xdist plugin. The reason this is necessary is that conventional Travis environments
+  # may report a large amount of available CPUs, but they they are greatly restricted. Through trial
+  # and error we found that more than 1 process may result in failures.
+  - PYTEST_PROCESSES=1 TOX_ENV=pylint_code
+  - PYTEST_PROCESSES=1 TOX_ENV=pylint_tests
+  - PYTEST_PROCESSES=1 TOX_ENV=py27
+  - PYTEST_PROCESSES=1 TOX_ENV=py26
+  - PYTEST_PROCESSES=1 TOX_ENV=py27e2e
+  - PYTEST_PROCESSES=1 TOX_ENV=py26e2e
+  - PYTEST_PROCESSES=1 TOX_ENV=py27ssh
+  - PYTEST_PROCESSES=1 TOX_ENV=py26ssh
+  - PYTEST_PROCESSES=1 TOX_ENV=docs
 
-install:
+before_install:
+  # Create SSH keys for SSH tests
+  - ssh-keygen -f $HOME/.ssh/id_rsa -t rsa -N ''
+  - cat $HOME/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
+
+  # Python dependencies
   - pip install --upgrade pip
   - pip install --upgrade setuptools
   - pip install tox
+  - tox --version
 
 script:
-  - pip --version
-  - tox --version
-  - PYTEST_PROCESSES=1 tox -e $TOX_ENV
-
-# The PYTEST_PROCESSES environment var is used in tox.ini to override the --numprocesses argument
-# for PyTest's xdist plugin. The reason this is necessary is that conventional Travis environments
-# may report a large amount of available CPUs, but they they are greatly restricted. Through trial
-# and error we found that more than 1 process may result in failures.
+  - tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -36,26 +36,28 @@ To install ARIA directly from PyPI (using a ``wheel``), use::
     pip install apache-ariatosca
 
 To install ARIA from source, download the source tarball from
-`PyPI <https://pypi.python.org/pypi/apache-ariatosca>`__, extract and ``cd`` into the extract dir, and run::
+`PyPI <https://pypi.python.org/pypi/apache-ariatosca>`__, extract and ``cd`` into the extract dir,
+and run::
 
     pip install --upgrade pip setuptools
     pip install .
 
-| The source package comes along with relevant examples, documentation, ``requirements.txt`` (for installing specifically the frozen dependencies' versions with which ARIA was tested) and more.
-|
+| The source package comes along with relevant examples, documentation, ``requirements.txt`` (for
+| installing specifically the frozen dependencies' versions with which ARIA was tested) and more.
 |
 | ARIA has additional optional dependencies. These are required for running operations over SSH.
-| Below are instructions on how to install these dependencies, including required system dependencies per OS.
+| Below are instructions on how to install these dependencies, including required system
+| dependencies per OS.
 |
-| Note: These dependencies may have varying licenses which may not be compatible with Apache license 2.0.
-|
+| Note: These dependencies may have varying licenses which may not be compatible with Apache license
+| 2.0.
 
-**Ubuntu/Debian** (tested on Ubuntu14.04, Ubuntu16.04)::
+**Ubuntu/Debian** (tested on Ubuntu 14.04, Ubuntu 16.04)::
 
     apt-get install -y python-dev gcc libffi-dev libssl-dev
     pip install apache-ariatosca[ssh]
 
-**Centos** (tested on Centos6.6, Centos7)::
+**CentOS/Fedora** (tested on CentOS 6.6, CentOS 7)::
 
     yum install -y python-devel gcc libffi-devel openssl-devel
     pip install apache-ariatosca[ssh]
@@ -65,7 +67,7 @@ To install ARIA from source, download the source tarball from
     pacman -Syu --noconfirm python2 gcc libffi openssl
     pip2 install apache-ariatosca[ssh]
 
-**Windows** (tested on Win10)::
+**Windows** (tested on Windows 10)::
 
     # no additional system requirements are needed
     pip install apache-ariatosca[ssh]
@@ -76,7 +78,7 @@ To install ARIA from source, download the source tarball from
 
 
 
-To install ``pip``, either use your distro's package management system, or run::
+To install ``pip``, either use your operating system's package management system, or run::
 
     wget http://bootstrap.pypa.io/get-pip.py
     python get-pip.py
@@ -91,7 +93,7 @@ This section will describe how to run a simple "Hello World" example.
 First, provide ARIA with the ARIA "hello world" service-template and name it (e.g.
 ``my-service-template``)::
 
-    aria service-templates store examples/hello-world/helloworld.yaml my-service-template
+    aria service-templates store examples/hello-world/hello-world.yaml my-service-template
 
 Now create a service based on this service-template and name it (e.g. ``my-service``)::
 
@@ -117,7 +119,8 @@ Contribution
 You are welcome and encouraged to participate and contribute to the ARIA project.
 
 Please see our guide to
-`Contributing to ARIA <https://cwiki.apache.org/confluence/display/ARIATOSCA/Contributing+to+ARIA>`__.
+`Contributing to ARIA
+<https://cwiki.apache.org/confluence/display/ARIATOSCA/Contributing+to+ARIA>`__.
 
 Feel free to also provide feedback on the mailing lists (see `Resources <#user-content-resources>`__
 section).
@@ -126,12 +129,12 @@ section).
 Resources
 ---------
 
--  `ARIA homepage <http://ariatosca.incubator.apache.org/>`__
--  `ARIA wiki <https://cwiki.apache.org/confluence/display/AriaTosca>`__
+- `ARIA homepage <http://ariatosca.incubator.apache.org/>`__
+- `ARIA wiki <https://cwiki.apache.org/confluence/display/AriaTosca>`__
 -  `Issue tracker <https://issues.apache.org/jira/browse/ARIA>`__
 
--  Dev mailing list: dev@ariatosca.incubator.apache.org
--  User mailing list: user@ariatosca.incubator.apache.org
+- Dev mailing list: dev@ariatosca.incubator.apache.org
+- User mailing list: user@ariatosca.incubator.apache.org
 
 Subscribe by sending a mail to ``<group>-subscribe@ariatosca.incubator.apache.org`` (e.g.
 ``dev-subscribe@ariatosca.incubator.apache.org``). See information on how to subscribe to mailing

--- a/aria/modeling/functions.py
+++ b/aria/modeling/functions.py
@@ -19,6 +19,7 @@ Mechanism for evaluating intrinsic functions.
 from ..parser.exceptions import InvalidValueError
 from ..parser.consumption import ConsumptionContext
 from ..utils.collections import OrderedDict
+from ..utils.type import full_type_name
 from . import exceptions
 
 
@@ -88,7 +89,8 @@ def evaluate(value, container_holder, report_issues=False): # pylint: disable=to
             if (evaluation is None) \
                 or (not hasattr(evaluation, 'value')) \
                 or (not hasattr(evaluation, 'final')):
-                raise InvalidValueError('bad __evaluate__ implementation')
+                raise InvalidValueError('bad __evaluate__ implementation: {0}'
+                                        .format(full_type_name(value)))
 
             evaluated = True
             value = evaluation.value

--- a/aria/modeling/service_common.py
+++ b/aria/modeling/service_common.py
@@ -28,7 +28,7 @@ from sqlalchemy.ext.declarative import declared_attr
 
 from ..utils import (
     collections,
-    formatting,
+    formatting
 )
 from .mixins import InstanceModelMixin, TemplateModelMixin, ParameterMixin
 from . import relationship

--- a/aria/modeling/service_instance.py
+++ b/aria/modeling/service_instance.py
@@ -38,7 +38,7 @@ from .mixins import InstanceModelMixin
 
 from ..utils import (
     collections,
-    formatting,
+    formatting
 )
 
 
@@ -227,6 +227,36 @@ class ServiceBase(InstanceModelMixin):
 
     :type: :class:`~datetime.datetime`
     """)
+
+    def get_node_by_type(self, type_name):
+        """
+        Finds the first node of a type (or descendent type).
+        """
+        service_template = self.service_template
+
+        if service_template is not None:
+            node_types = service_template.node_types
+            if node_types is not None:
+                for node in self.nodes.itervalues():
+                    if node_types.is_descendant(type_name, node.type.name):
+                        return node
+
+        return None
+
+    def get_policy_by_type(self, type_name):
+        """
+        Finds the first policy of a type (or descendent type).
+        """
+        service_template = self.service_template
+
+        if service_template is not None:
+            policy_types = service_template.policy_types
+            if policy_types is not None:
+                for policy in self.policies.itervalues():
+                    if policy_types.is_descendant(type_name, policy.type.name):
+                        return policy
+
+        return None
 
     @property
     def as_raw(self):
@@ -479,14 +509,15 @@ class NodeBase(InstanceModelMixin):
 
     @classmethod
     def determine_state(cls, op_name, is_transitional):
-        """ :returns the state the node should be in as a result of running the
-            operation on this node.
+        """
+        :returns the state the node should be in as a result of running the operation on this node.
 
-            e.g. if we are running tosca.interfaces.node.lifecycle.Standard.create, then
-            the resulting state should either 'creating' (if the task just started) or 'created'
-            (if the task ended).
+        E.g. if we are running tosca.interfaces.node.lifecycle.Standard.create, then
+        the resulting state should either 'creating' (if the task just started) or 'created'
+        (if the task ended).
 
-            If the operation is not a standard tosca lifecycle operation, then we return None"""
+        If the operation is not a standard TOSCA lifecycle operation, then we return None.
+        """
 
         state_type = 'transitional' if is_transitional else 'finished'
         try:
@@ -497,11 +528,24 @@ class NodeBase(InstanceModelMixin):
     def is_available(self):
         return self.state not in (self.INITIAL, self.DELETED, self.ERROR)
 
+    def get_outbound_relationship_by_name(self, name):
+        for the_relationship in self.outbound_relationships:
+            if the_relationship.name == name:
+                return the_relationship
+        return None
+
+    def get_inbound_relationship_by_name(self, name):
+        for the_relationship in self.inbound_relationships:
+            if the_relationship.name == name:
+                return the_relationship
+        return None
+
     @property
     def host_address(self):
         if self.host and self.host.attributes:
             attribute = self.host.attributes.get('ip')
-            return attribute.value if attribute else None
+            if attribute is not None:
+                return attribute.value
         return None
 
     @property

--- a/aria/orchestrator/topology/template_handler.py
+++ b/aria/orchestrator/topology/template_handler.py
@@ -206,12 +206,15 @@ class CapabilityTemplate(common.TemplateHandlerBase):
         self._topology.coerce(self._model.properties, **kwargs)
 
     def instantiate(self, instance_cls, **_):
-        return instance_cls(name=self._model.name,
-                            type=self._model.type,
-                            min_occurrences=self._model.min_occurrences,
-                            max_occurrences=self._model.max_occurrences,
-                            occurrences=0,
-                            capability_template=self._model)
+        capability = instance_cls(
+            name=self._model.name,
+            type=self._model.type,
+            min_occurrences=self._model.min_occurrences,
+            max_occurrences=self._model.max_occurrences,
+            occurrences=0,
+            capability_template=self._model)
+        capability.properties = self._topology.instantiate(self._model.properties)
+        return capability
 
     def validate(self, **kwargs):
         self._topology.validate(self._model.properties, **kwargs)
@@ -446,7 +449,7 @@ class SubstitutionTemplate(common.TemplateHandlerBase):
 class SubstitutionTemplateMapping(common.TemplateHandlerBase):
 
     def dump(self, out_stream):
-        if self._topology.capability_template is not None:
+        if self._model.capability_template is not None:
             node_template = self._model.capability_template.node_template
         else:
             node_template = self._model.requirement_template.node_template

--- a/aria/orchestrator/topology/topology.py
+++ b/aria/orchestrator/topology/topology.py
@@ -57,11 +57,11 @@ class Topology(issue.ReporterMixin):
     @staticmethod
     def _init_handlers(module_):
         """
-        Register handlers from a handler module to the models
+        Register handlers from a handler module to the models.
 
-        :param module_: The module to look for handlers
-        :return: a dict where the key is the models class, and the value is the handler class
-        associated with it from the provided module
+        :param module_: the module to look for handlers
+        :returns: dict where the key is the models class, and the value is the handler class
+         associated with it from the provided module
         """
         handlers = {}
         for attribute_name in dir(module_):
@@ -74,11 +74,11 @@ class Topology(issue.ReporterMixin):
 
     def instantiate(self, model, **kwargs):
         """
-        instantiate the provided model
+        Instantiate the provided model.
 
         :param model:
         :param kwargs:
-        :return:
+        :returns:
         """
         if isinstance(model, dict):
             return dict((name, self.instantiate(value, **kwargs))

--- a/examples/clearwater/clearwater-live-test-existing.yaml
+++ b/examples/clearwater/clearwater-live-test-existing.yaml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+description: >-
+  Project Clearwater is an open-source IMS core, developed by Metaswitch Networks and released under
+  the GNU GPLv3.
+
+metadata:
+  template_name: clearwater-live-test-existing
+  template_author: ARIA
+  template_version: '1.0'
+  aria_version: '0.2.0'
+
+imports:
+  - types/clearwater.yaml
+  - aria-1.0
+
+topology_template:
+
+  inputs:
+    hosts.ssh.user:
+      type: string
+    hosts.ssh.password:
+      type: string
+    existing_host.public_address:
+      type: string
+
+  node_templates:
+    live_test:
+      type: clearwater.LiveTest
+
+    existing_host:
+      type: clearwater.HostBase
+      attributes:
+        public_address: { get_input: existing_host.public_address }
+      capabilities:
+        host:
+          properties:
+            ssh.user: { get_input: hosts.ssh.user }
+            ssh.password: { get_input: hosts.ssh.password }

--- a/examples/clearwater/clearwater-single-existing.yaml
+++ b/examples/clearwater/clearwater-single-existing.yaml
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+description: >-
+  Project Clearwater is an open-source IMS core, developed by Metaswitch Networks and released under
+  the GNU GPLv3.
+
+metadata:
+  template_name: clearwater-single-existing
+  template_author: ARIA
+  template_version: '1.0'
+  aria_version: '0.2.0'
+
+imports:
+  - types/clearwater.yaml
+  - aria-1.0
+
+topology_template:
+
+  inputs:
+    hosts.ssh.user:
+      description: >-
+        Existing SSH user.
+      type: string
+    hosts.ssh.password:
+      description: >-
+        Existing SSH password.
+      type: string
+    existing_host.public_address:
+      description: >-
+        Existing IP address that can be accessed by ARIA.
+      type: string
+    existing_host.private_address:
+      description: >-
+        Existing IP address that can be accessed within the service.
+      type: string
+      default: { get_input: existing_host.public_address }
+    existing_host.hostname:
+      description: >-
+        The hostname will be changed to this.
+      type: string
+      default: aria-clearwater-single
+
+  node_templates:
+    bono:
+      type: clearwater.Bono
+      requirements:
+        - sip_downstream: clearwater.Sprout
+        - sip_secure_downstream: clearwater.Sprout
+        - ralf: clearwater.Ralf
+
+    sprout:
+      type: clearwater.Sprout
+      requirements:
+        - ralf: clearwater.Ralf
+# cyclical: see ARIA-327
+#        - sip_upstream: clearwater.Bono
+
+    dime:
+      type: clearwater.Dime
+
+    homestead:
+      type: clearwater.Homestead
+
+    ralf:
+      type: clearwater.Ralf
+      description: >-
+        Optional, only required if you are using a CCF (Charging Collection Function).
+
+    homer:
+      type: clearwater.Homer
+
+    vellum:
+      type: clearwater.Vellum
+#      requirements:
+# cyclical: see ARIA-327
+#        - ralf: clearwater.Ralf
+
+    i-cscf:
+      type: clearwater.I-CSCF
+
+    s-cscf:
+      type: clearwater.S-CSCF
+
+    ellis:
+      type: clearwater.Ellis
+      description: >-
+        Optional, only required if you want a web frontend.
+      properties:
+        provision_numbers_count: 1000
+      requirements:
+        - ralf: clearwater.Ralf
+
+    existing_host:
+      type: clearwater.Host
+      attributes:
+        public_address: { get_input: existing_host.public_address }
+        private_address: { get_input: existing_host.private_address }
+      capabilities:
+        host:
+          properties:
+            hostname: { get_input: existing_host.hostname }
+            ssh.user: { get_input: hosts.ssh.user }
+            ssh.password: { get_input: hosts.ssh.password }
+            max_log_directory_size: 50 MiB
+            reduce_cassandra_mem_usage: true
+
+    smtp:
+      type: smtp.SMTP
+      properties:
+        address: 127.0.0.1
+      capabilities:
+        smtp:
+          properties:
+            username: username
+            password: password
+
+  policies:
+    configuration:
+      type: clearwater.Configuration
+      properties:
+        zone: example.com
+        secret: secret
+
+  substitution_mappings:
+    node_type: ims.nodes.IMS
+    capabilities:
+       p-cscf: [ bono, p-cscf ]
+       i-cscf: [ i-cscf, i-cscf ]
+       s-cscf: [ s-cscf, s-cscf ]
+       hss: [ homestead, hss ]
+       ctf: [ ralf, ctf ]
+       xdms: [ homer, xdms ]

--- a/examples/clearwater/scripts/bono/create.sh
+++ b/examples/clearwater/scripts/bono/create.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install bono
+yes | aptdcon --hide-terminal --install restund

--- a/examples/clearwater/scripts/bono/delete.sh
+++ b/examples/clearwater/scripts/bono/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/dime/create.sh
+++ b/examples/clearwater/scripts/dime/create.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Installs Homestead and Ralf
+yes | aptdcon --hide-terminal --install dime
+yes | aptdcon --hide-terminal --install clearwater-prov-tools

--- a/examples/clearwater/scripts/dime/delete.sh
+++ b/examples/clearwater/scripts/dime/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/ellis/configure.sh
+++ b/examples/clearwater/scripts/ellis/configure.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PROVISION_NUMBERS_START=$(ctx node properties provision_numbers_start)
+PROVISION_NUMBERS_COUNT=$(ctx node properties provision_numbers_count)
+
+if [ "$PROVISION_NUMBERS_COUNT" != 0 ]; then
+	cd /usr/share/clearwater/ellis
+	. env/bin/activate
+	python src/metaswitch/ellis/tools/create_numbers.py \
+		--start "$PROVISION_NUMBERS_START" \
+		--count "$PROVISION_NUMBERS_COUNT"
+	deactivate
+fi

--- a/examples/clearwater/scripts/ellis/create.sh
+++ b/examples/clearwater/scripts/ellis/create.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install ellis

--- a/examples/clearwater/scripts/ellis/delete.sh
+++ b/examples/clearwater/scripts/ellis/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/homer/create.sh
+++ b/examples/clearwater/scripts/homer/create.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install homer
+
+# ARIA fix to avoid warnings by Twisted for missing service_identity library
+# (Crest is used by both Homer and Homestead-prov)
+cd /usr/share/clearwater/crest
+. env/bin/activate
+pip install service_identity
+deactivate
+service homer restart

--- a/examples/clearwater/scripts/homer/delete.sh
+++ b/examples/clearwater/scripts/homer/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/homestead/create.sh
+++ b/examples/clearwater/scripts/homestead/create.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# ARIA fix to avoid warnings by Twisted for missing service_identity library
+# (Crest is used by both Homer and Homestead-prov)
+cd /usr/share/clearwater/crest
+. env/bin/activate
+pip install service_identity
+deactivate
+service homer restart

--- a/examples/clearwater/scripts/homestead/delete.sh
+++ b/examples/clearwater/scripts/homestead/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/host-base/configure.sh
+++ b/examples/clearwater/scripts/host-base/configure.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+if ! type aptdcon > /dev/null; then
+	# This will allow us to do concurrent installs
+	apt update
+	apt install aptdaemon --yes
+fi

--- a/examples/clearwater/scripts/host/configure.sh
+++ b/examples/clearwater/scripts/host/configure.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+HOSTNAME=$(ctx node capabilities host properties hostname)
+
+# Change hostname
+OLD_HOSTNAME=$(hostname)
+if [ "$OLD_HOSTNAME" != "$HOSTNAME" ]; then
+	hostname "$HOSTNAME"
+	echo "$HOSTNAME" > /etc/hostname
+	sed --in-place --expression "s/127.0.1.1\s\+$OLD_HOSTNAME/127.0.1.1 $HOSTNAME/" /etc/hosts
+fi
+
+ZONE=$(ctx service get_policy_by_type [ clearwater.Configuration ] properties zone)
+GEOGRAPHICALLY_REDUNDANT=$(ctx service get_policy_by_type [ clearwater.Configuration ] properties geographically_redundant)
+SITE_NAME=$(ctx service get_policy_by_type [ clearwater.Configuration ] properties site_name)
+SECRET=$(ctx service get_policy_by_type [ clearwater.Configuration ] properties secret)
+
+SMTP_HOSTNAME=$(ctx service get_node_by_type [ clearwater.Ellis ] get_outbound_relationship_by_name [ smtp ] target_node properties address)
+SMTP_USERNAME=$(ctx service get_node_by_type [ clearwater.Ellis ] get_outbound_relationship_by_name [ smtp ] target_node capabilities smtp properties username)
+SMTP_PASSWORD=$(ctx service get_node_by_type [ clearwater.Ellis ] get_outbound_relationship_by_name [ smtp ] target_node capabilities smtp properties password)
+
+MAX_LOG_DIRECTORY_SIZE=$(ctx node capabilities host properties max_log_directory_size value)
+REDUCE_CASSANDRA_MEM_USAGE=$(ctx node capabilities host properties reduce_cassandra_mem_usage)
+
+PRIVATE_IP=$(ctx node attributes private_address)
+PUBLIC_IP=$(ctx node attributes public_address)
+PUBLIC_HOSTNAME=$(hostname)
+# TODO: comma-separated list of all private IP addresses in group
+ETCD_CLUSTER=$PRIVATE_IP
+
+REPO_FILE=/etc/apt/sources.list.d/clearwater.list
+REPO_LINE='deb http://repo.cw-ngv.com/stable binary/'
+KEY_URL=http://repo.cw-ngv.com/repo_key
+
+
+#
+# Repository
+#
+
+if [ ! -f "$REPO_FILE" ]; then
+	echo "$REPO_LINE" > "$REPO_FILE"
+	curl --location "$KEY_URL" | apt-key add -
+fi
+
+apt update
+
+if ! type aptdcon > /dev/null; then
+	# This will allow us to do concurrent installs
+	apt install aptdaemon --yes
+fi
+
+yes | aptdcon --hide-terminal --install clearwater-management
+
+
+#
+# DNS
+#
+
+S_CSCF_HOST="$PRIVATE_IP scscf.$PUBLIC_HOSTNAME # ARIA"
+grep --quiet --fixed-strings "$S_CSCF_HOST" /etc/hosts || echo "$S_CSCF_HOST" >> /etc/hosts
+
+
+#
+# Local configuration
+#
+
+mkdir --parents /etc/clearwater
+CONFIG_FILE=/etc/clearwater/local_config
+echo "# Created by ARIA on $(date -u)" > "$CONFIG_FILE"
+
+echo >> "$CONFIG_FILE"
+echo "# Local IP configuration" >> "$CONFIG_FILE"
+echo "local_ip=$PRIVATE_IP" >> "$CONFIG_FILE"
+echo "public_ip=$PUBLIC_IP" >> "$CONFIG_FILE"
+echo "public_hostname=$PUBLIC_HOSTNAME" >> "$CONFIG_FILE"
+echo "etcd_cluster=$ETCD_CLUSTER" >> "$CONFIG_FILE"
+
+if [ "$MAX_LOG_DIRECTORY_SIZE" != 0 ]; then
+	echo >> "$CONFIG_FILE"
+	echo "max_log_directory_size=$MAX_LOG_DIRECTORY_SIZE" >> "$CONFIG_FILE"
+fi
+
+if [ "$GEOGRAPHICALLY_REDUNDANT" = True ]; then
+	echo >> "$CONFIG_FILE"
+	echo "# Geographically redundant" >> "$CONFIG_FILE"
+	echo "local_site_name=$SITE_NAME" >> "$CONFIG_FILE"
+
+	# On the first Vellum node in the second site, you should set remote_cassandra_seeds to the
+	# IP address of a Vellum node in the first site.
+	#echo "remote_cassandra_seeds=" >> "$CONFIG_FILE"
+fi
+
+
+#
+# Shared configuration
+#
+
+if [ "$GEOGRAPHICALLY_REDUNDANT" = True ]; then
+	SPROUT_HOSTNAME=sprout.$SITE_NAME.$ZONE
+	SPROUT_REGISTRATION_STORE=vellum.$SITE_NAME.$ZONE
+	HS_HOSTNAME=hs.$SITE_NAME.$ZONE:8888
+	HS_PROVISIONING_HOSTNAME=hs.$SITE_NAME.$ZONE:8889
+	RALF_HOSTNAME=ralf.$SITE_NAME.$ZONE:10888
+	RALF_SESSION_STORE=vellum.$ZONE
+	XDMS_HOSTNAME=homer.$SITE_NAME.$ZONE:7888
+	CHRONOS_HOSTNAME=vellum.$SITE_NAME.$ZONE
+	CASSANDRA_HOSTNAME=vellum.$SITE_NAME.$ZONE
+else
+	VELLUM_IP=$PRIVATE_IP
+	HOMESTEAD_IP=$PRIVATE_IP
+	HOMER_IP=$PRIVATE_IP
+
+	SPROUT_HOSTNAME=$PUBLIC_HOSTNAME
+	SPROUT_REGISTRATION_STORE=$VELLUM_IP
+	HS_HOSTNAME=$HOMESTEAD_IP:8888
+	HS_PROVISIONING_HOSTNAME=$HOMESTEAD_IP:8889
+	RALF_HOSTNAME=
+	RALF_SESSION_STORE=
+	XDMS_HOSTNAME=$HOMER_IP:7888
+	CHRONOS_HOSTNAME=
+	CASSANDRA_HOSTNAME=
+fi
+
+mkdir --parents /etc/clearwater
+CONFIG_FILE=/etc/clearwater/shared_config
+echo "# Created by ARIA on $(date -u)" > "$CONFIG_FILE"
+
+echo >> "$CONFIG_FILE"
+echo "# Deployment definitions" >> "$CONFIG_FILE"
+echo "home_domain=$ZONE" >> "$CONFIG_FILE"
+echo "sprout_hostname=$SPROUT_HOSTNAME" >> "$CONFIG_FILE"
+echo "sprout_registration_store=$SPROUT_REGISTRATION_STORE" >> "$CONFIG_FILE"
+echo "hs_hostname=$HS_HOSTNAME" >> "$CONFIG_FILE"
+echo "hs_provisioning_hostname=$HS_PROVISIONING_HOSTNAME" >> "$CONFIG_FILE"
+echo "ralf_hostname=$RALF_HOSTNAME" >> "$CONFIG_FILE"
+echo "ralf_session_store=$RALF_SESSION_STORE" >> "$CONFIG_FILE"
+echo "xdms_hostname=$XDMS_HOSTNAME" >> "$CONFIG_FILE"
+echo "chronos_hostname=$CHRONOS_HOSTNAME" >> "$CONFIG_FILE"
+echo "cassandra_hostname=$CASSANDRA_HOSTNAME" >> "$CONFIG_FILE"
+
+echo >> "$CONFIG_FILE"
+echo "# Email server configuration" >> "$CONFIG_FILE"
+echo "smtp_smarthost=$SMTP_HOSTNAME" >> "$CONFIG_FILE"
+echo "smtp_username=$SMTP_USERNAME" >> "$CONFIG_FILE"
+echo "smtp_password=$SMTP_PASSWORD" >> "$CONFIG_FILE"
+echo "email_recovery_sender=clearwater@$ZONE" >> "$CONFIG_FILE"
+
+echo >> "$CONFIG_FILE"
+echo "# I-CSCF/S-CSCF configuration (used by Bono to proxy to Sprout)" >> "$CONFIG_FILE"
+echo "upstream_hostname=scscf.$HOSTNAME" >> "$CONFIG_FILE"
+
+echo >> "$CONFIG_FILE"
+echo "# Keys" >> "$CONFIG_FILE"
+echo "signup_key=$SECRET" >> "$CONFIG_FILE"
+echo "turn_workaround=$SECRET" >> "$CONFIG_FILE"
+echo "ellis_api_key=$SECRET" >> "$CONFIG_FILE"
+echo "ellis_cookie_key=$SECRET" >> "$CONFIG_FILE"
+
+if [ "$REDUCE_CASSANDRA_MEM_USAGE" = True ]; then
+	echo >> "$CONFIG_FILE"
+	echo "# $REDUCE_CASSANDRA_MEM_USAGE" >> "$CONFIG_FILE"
+	echo "reduce_cassandra_mem_usage=Y" >> "$CONFIG_FILE"
+fi
+
+# Copy to other hosts in etcd group
+#yes | aptdcon --hide-terminal --install clearwater-config-manager
+#cw-upload_shared_config

--- a/examples/clearwater/scripts/live-test/create.sh
+++ b/examples/clearwater/scripts/live-test/create.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+LIB=/opt/clearwater-live-test
+COMMAND=/usr/bin/clearwater-live-test
+RUBY_VERSION=1.9.3
+RVM=/usr/local/rvm
+QUAFF_OLD_URL=git@github.com:metaswitch/quaff.git
+QUAFF_NEW_URL=https://github.com/Metaswitch/quaff.git
+
+# Build requirements
+yes | aptdcon --hide-terminal --install build-essential
+yes | aptdcon --hide-terminal --install bundler
+yes | aptdcon --hide-terminal --install git
+
+# Required by nokogiri Ruby gem
+yes | aptdcon --hide-terminal --install zlib1g-dev
+
+# Install Ruby enVironment Manager
+if [ ! -d "$RVM" ]; then
+	# Install
+	curl --location https://get.rvm.io | bash -s stable
+fi
+
+# Install Ruby using RVM
+. "$RVM/scripts/rvm"
+rvm autolibs enable
+rvm install "$RUBY_VERSION"
+rvm use "$RUBY_VERSION@global"
+
+# Install Clearwater Live Test
+if [ ! -d "$LIB" ]; then
+	mkdir --parents /opt
+	cd /opt
+	git clone --depth 1 https://github.com/Metaswitch/clearwater-live-test.git
+	cd clearwater-live-test
+	chmod a+rw -R .
+
+	# Note: we must fix the URLs for Quaff
+	sed --in-place --expression "s,$QUAFF_OLD_URL,$QUAFF_NEW_URL,g" Gemfile Gemfile.lock
+
+	# Install required Ruby gems 
+	bundle install
+fi
+
+# Create command
+echo "#!/bin/bash" > "$COMMAND"
+echo ". \"$RVM/scripts/rvm\"" >> "$COMMAND"
+echo "rvm use \"$RUBY_VERSION@global\"" >> "$COMMAND"
+echo "cd \"$LIB\"" >> "$COMMAND"
+echo "rake \"\$@\"" >> "$COMMAND"
+chmod a+x "$COMMAND"
+
+# clearwater-live-test test[example.com] SIGNUP_CODE=secret PROXY=192.168.1.171 ELLIS=192.168.1.171

--- a/examples/clearwater/scripts/live-test/delete.sh
+++ b/examples/clearwater/scripts/live-test/delete.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+LIB=/opt/clearwater-live-test
+COMMAND=/usr/bin/clearwater-live-test
+
+rm --recursive --force "$LIB"
+rm --force "$COMMAND"

--- a/examples/clearwater/scripts/memento/create.sh
+++ b/examples/clearwater/scripts/memento/create.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install memento-as
+yes | aptdcon --hide-terminal --install memento-nginx

--- a/examples/clearwater/scripts/memento/delete.sh
+++ b/examples/clearwater/scripts/memento/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/ralf/create.sh
+++ b/examples/clearwater/scripts/ralf/create.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/examples/clearwater/scripts/ralf/delete.sh
+++ b/examples/clearwater/scripts/ralf/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/sprout/create.sh
+++ b/examples/clearwater/scripts/sprout/create.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install sprout

--- a/examples/clearwater/scripts/sprout/delete.sh
+++ b/examples/clearwater/scripts/sprout/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/scripts/vellum/create.sh
+++ b/examples/clearwater/scripts/vellum/create.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yes | aptdcon --hide-terminal --install vellum
+
+# Memento
+# TODO: see if there is a Memento node
+#yes | aptdcon --hide-terminal --install memento-cassandra

--- a/examples/clearwater/scripts/vellum/delete.sh
+++ b/examples/clearwater/scripts/vellum/delete.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TODO

--- a/examples/clearwater/types/cassandra.yaml
+++ b/examples/clearwater/types/cassandra.yaml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+capability_types:
+
+  cassandra.Endpoint:
+    derived_from: tosca.capabilities.Endpoint.Database
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 7000
+
+  cassandra.Endpoint.Thrift:
+    derived_from: tosca.capabilities.Endpoint.Database
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 9160

--- a/examples/clearwater/types/clearwater.yaml
+++ b/examples/clearwater/types/clearwater.yaml
@@ -1,0 +1,728 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+  - ims.yaml
+  - smtp.yaml
+  - cassandra.yaml
+
+dsl_definitions:
+
+  clearwater_operation_dependencies: &CLEARWATER_OPERATION_DEPENDENCIES
+    - "ssh.user > { get_property: [ HOST, host, ssh.user ] }"
+    - "ssh.password > { get_property: [ HOST, host, ssh.password ] }"
+    - "ssh.address > { get_attribute: [ HOST, public_address ] }"
+    - "ssh.use_sudo > true"
+
+policy_types:
+
+  clearwater.Configuration:
+    derived_from: tosca.policies.Root
+    properties:
+      zone:
+        description: >-
+          The domain name for SIP addresses, for example if its "example.com" then a SIP address
+          could be "6505550243@example.com".
+        type: string
+      geographically_redundant:
+        description: >-
+          Enable a geographically redundant deployment.
+        
+          See: http://clearwater.readthedocs.io/en/stable/Geographic_redundancy.html
+        type: boolean
+        default: false
+      site_name:
+        description: >-
+          Used by geographically redundant deployments.
+        type: string
+        required: false
+      secret:
+        description: >-
+          Used for registration via Ellis.
+        type: string
+
+capability_types:
+
+  clearwater.Container:
+    description: >-
+      Clearwater container capability.
+    derived_from: tosca.capabilities.Container
+    properties:
+      hostname:
+        type: string
+      ssh.user:
+        type: string
+      ssh.password:
+        type: string
+      max_log_directory_size:
+        type: scalar-unit.size
+        default: 0 B # 0 means no max size
+      reduce_cassandra_mem_usage:
+        type: boolean
+        default: false
+
+  # http://clearwater.readthedocs.io/en/stable/Clearwater_IP_Port_Usage.html
+
+  # SIP endpoints
+
+  clearwater.Endpoint.SIP.Upstream:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 5052
+
+  clearwater.Endpoint.SIP.Upstream.Secure:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 5054
+      secure: # override
+        type: boolean
+        default: true
+
+  clearwater.Endpoint.SIP.Proxy:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 5058
+
+  clearwater.Endpoint.SIP.Public:
+    derived_from: tosca.capabilities.Endpoint.Public
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 5060
+
+  clearwater.Endpoint.SIP.Public.Secure:
+    derived_from: tosca.capabilities.Endpoint.Public
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 5062
+      secure: # override
+        type: boolean
+        default: true
+
+  # STUN endpoints
+
+  clearwater.Endpoint.STUN:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: stun
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 3478
+
+  # Diameter endpoints
+
+  clearwater.Endpoint.Diameter.HSS:
+    description: >-
+      In shared_config: hs_listen_port
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: diameter
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 3868
+
+  clearwater.Endpoint.Diameter.CTF:
+    description: >-
+      In shared_config: ralf_listen_port
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: diameter
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 3869
+
+  # Management endpoints
+
+  clearwater.Endpoint.Management.Homer:
+    derived_from: ims.interfaces.HTTP
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 7888
+
+  clearwater.Endpoint.Management.Homestead:
+    derived_from: ims.interfaces.HTTP
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 8888
+
+  clearwater.Endpoint.Management.Homestead.Provisioning:
+    description: >-
+      In shared_config: homestead_provisioning_port
+    derived_from: ims.interfaces.HTTP
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 8889
+
+  clearwater.Endpoint.Management.Sprout:
+    derived_from: ims.interfaces.HTTP
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 9886
+
+  clearwater.Endpoint.Management.Ralf:
+    derived_from: ims.interfaces.HTTP
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 9888 # note: some documentation shows 10888
+
+  # Web endpoints
+
+  clearwater.Endpoint.Public.Web:
+    derived_from: tosca.capabilities.Endpoint.Public
+    properties:
+      protocol: # override
+        type: string
+        default: http
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 80
+      url_path: # override
+        type: string
+        default: /
+
+  clearwater.Endpoint.Public.Web.Secure:
+    derived_from: tosca.capabilities.Endpoint.Public
+    properties:
+      protocol: # override
+        type: string
+        default: https
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 443
+      secure: # override
+        type: boolean
+        default: true
+      url_path: # override
+        type: string
+        default: /        
+
+  # Other endpoints
+
+  clearwater.Endpoint.Chronos:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 7253
+
+  clearwater.Endpoint.Memcached:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 11211
+
+  clearwater.Endpoint.Astaire:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      port: # override
+        type: tosca.datatypes.network.PortDef
+        default: 11311
+
+data_types:
+
+  clearwater.Number:
+    derived_from: string
+    constraints:
+      - pattern: '^\d{10}$'
+
+node_types:
+
+  # http://clearwater.readthedocs.io/en/stable/Clearwater_Architecture.html
+
+  clearwater.SoftwareComponent:
+    description: >-
+      Clearwater software components must be installed in a Clearwater-capable compute node.
+    derived_from: tosca.nodes.SoftwareComponent
+    requirements:
+      - host: # override
+          capability: clearwater.Container
+          relationship: tosca.relationships.HostedOn
+
+  clearwater.Bono:
+    description: >-
+      Clearwater edge proxy.
+
+      The Bono nodes form a horizontally scalable SIP edge proxy providing both a SIP IMS Gm
+      compliant interface and a WebRTC interface to clients. Client connections are load balanced
+      across the nodes. The Bono node provides the anchor point for the client's connection to the
+      Clearwater system, including support for various NAT traversal mechanisms. A client is
+      therefore anchored to a particular Bono node for the duration of its registration, but can
+      move to another Bono node if the connection or client fails.
+
+      Clients can connect to Bono using SIP/UDP or SIP/TCP. Bono supports any WebRTC client that
+      performs call setup signaling using SIP over WebSocket.
+
+      Alternatively, Clearwater can be deployed with a third party P-CSCF or Session Border
+      Controller implementing P-CSCF. In this case Bono nodes are not required.
+    derived_from: clearwater.SoftwareComponent
+    capabilities:
+      p-cscf: ims.functions.P-CSCF
+      gm: ims.interfaces.Gm
+      sip_endpoint: clearwater.Endpoint.SIP.Public
+      sip_secure_endpoint: clearwater.Endpoint.SIP.Public.Secure
+      sip_proxy: clearwater.Endpoint.SIP.Proxy # open to Sprout
+      stun_endoint: clearwater.Endpoint.STUN
+    requirements:
+      - sip_downstream:
+          capability: clearwater.Endpoint.SIP.Upstream
+          occurrences: [ 0, UNBOUNDED ]       
+      - sip_secure_downstream:
+          capability: clearwater.Endpoint.SIP.Upstream.Secure
+          occurrences: [ 0, UNBOUNDED ]       
+      - ralf: # for billable events
+          capability: clearwater.Endpoint.Management.Ralf
+          occurrences: [ 0, 1 ]       
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/bono/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/bono/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Sprout:
+    description: >-
+      Clearwater SIP router.
+
+      The Sprout nodes act as a horizontally scalable, combined SIP registrar and authoritative
+      routing proxy, and handle client authentication and the ISC interface to application servers.
+      The Sprout nodes also contain the in-built MMTEL application server. SIP transactions are load
+      balanced across the Sprout cluster, so there is no long-lived association between a client and
+      a particular Sprout node. Sprout does not store any long-lived data itself and instead uses
+      web service interfaces to Homestead and Homer to retrieve HSS configuration such as
+      authentication data/user profiles and MMTEL service settings APIs to Vellum for storing
+      subscriber registration data and for running timers.
+
+      Sprout is where the bulk of the I-CSCF and S-CSCF function resides, with the remainder
+      provided by Dime (and backed by the long-lived data stores on Vellum).            
+    derived_from: clearwater.SoftwareComponent
+    capabilities:
+      sip_endpoint: clearwater.Endpoint.SIP.Upstream # open to Bono
+      sip_secure_endpoint: clearwater.Endpoint.SIP.Upstream.Secure # open to Bono
+      management_endpoint: clearwater.Endpoint.Management.Sprout
+      memento:
+        type: tosca.capabilities.Container
+        valid_source_types: [ clearwater.Memento ]
+    requirements:
+# cyclical: see ARIA-327
+#      - sip_upstream:
+#          capability: clearwater.Endpoint.SIP.Proxy      
+#          occurrences: [ 0, UNBOUNDED ]       
+      - homer: # for subscriber profiles
+          capability: clearwater.Endpoint.Management.Homer
+      - ralf: # for billable events
+          capability: clearwater.Endpoint.Management.Ralf
+          occurrences: [ 0, 1 ]       
+      - chronos:
+          capability: clearwater.Endpoint.Chronos
+          node: clearwater.Vellum
+      - astaire:
+          capability: clearwater.Endpoint.Astaire
+          node: clearwater.Vellum
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/sprout/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/sprout/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Memento:
+    derived_from: tosca.nodes.Root
+    capabilities:
+      sip-as: ims.functions.SIP-AS
+      web_secure_endpoint: clearwater.Endpoint.Public.Web.Secure
+    requirements:
+      - host:
+          capability: tosca.capabilities.Container
+          node: clearwater.Sprout
+      - cassandra_thrift:
+          capability: cassandra.Endpoint.Thrift
+          node: clearwater.Vellum
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/memento/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/memento/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Dime:
+    description: >-
+      Clearwater Diameter gateway.
+
+      Dime nodes run Clearwater's Homestead and Ralf components.
+    derived_from: clearwater.SoftwareComponent
+    capabilities:
+      host:
+         type: tosca.capabilities.Container
+         valid_source_types: [ clearwater.DimeSoftwareComponent ]
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/dime/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/dime/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.DimeSoftwareComponent:
+    description: >-
+      Base type for Dime software components.
+    derived_from: clearwater.SoftwareComponent
+    requirements:
+      - host: # override
+          capability: tosca.capabilities.Container
+          node: clearwater.Dime
+
+  clearwater.Homestead:
+    description: >-
+      Clearwater HSS cache.
+
+      Homestead provides a web services interface to Sprout for retrieving authentication
+      credentials and user profile information. It can either master the data (in which case it
+      exposes a web services provisioning interface) or can pull the data from an IMS compliant HSS
+      over the Cx interface. The Homestead nodes themselves are stateless - the mastered / cached
+      subscriber data is all stored on Vellum (via Cassandra's Thrift interface).
+
+      In the IMS architecture, the HSS mirror function is considered to be part of the I-CSCF and
+      S-CSCF components, so in Clearwater I-CSCF and S-CSCF function is implemented with a
+      combination of Sprout and Dime clusters.
+    derived_from: clearwater.DimeSoftwareComponent
+    capabilities:
+      hss: ims.functions.HSS
+      cx: ims.interfaces.Cx
+      diameter_endpoint: clearwater.Endpoint.Diameter.HSS
+      management_endpoint: clearwater.Endpoint.Management.Homestead # open to Ellis
+      provisioning_management_endpoint: clearwater.Endpoint.Management.Homestead.Provisioning # open to Ellis
+    requirements:
+      - cassandra_thrift:
+          capability: cassandra.Endpoint.Thrift
+          node: clearwater.Vellum
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/homestead/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/homestead/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Ralf:
+    description: >-
+      Clearwater CTF.
+
+      Ralf provides an HTTP API that both Bono and Sprout can use to report billable events that
+      should be passed to the CDF (Charging Data Function) over the Rf billing interface. Ralf is
+      stateless, using Vellum to maintain the long lived session state and run the timers necessary
+      to enable it to conform to the Rf protocol.
+    derived_from: clearwater.DimeSoftwareComponent
+    capabilities:
+      ctf: ims.functions.CTF
+      rf: ims.interfaces.Rf
+      diameter_endpoint: clearwater.Endpoint.Diameter.CTF
+      management_endpoint: clearwater.Endpoint.Management.Ralf # open to Sprout, Bono, Vellum
+    requirements:
+      - chronos:
+          capability: clearwater.Endpoint.Chronos
+          node: clearwater.Vellum
+      - astaire:
+          capability: clearwater.Endpoint.Astaire
+          node: clearwater.Vellum
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/ralf/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/ralf/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Vellum:
+    description: >-
+      Clearwater state store.
+
+      Vellum is used to maintain all long-lived state in the deployment. It does this by running a
+      number of cloud optimized, distributed storage clusters.
+
+      - Cassandra. Cassandra is used by Homestead to store authentication credentials and profile
+      information, and is used by Homer to store MMTEL service settings. Vellum exposes Cassandra's
+      Thrift API.
+
+      - etcd. etcd is used by Vellum itself to share clustering information between Vellum nodes and
+      by other nodes in the deployment for shared configuration.
+
+      - Chronos. Chronos is a distributed, redundant, reliable timer service developed by
+      Clearwater. It is used by Sprout and Ralf nodes to enable timers to be run (e.g. for SIP
+      Registration expiry) without pinning operations to a specific node (one node can set the timer
+      and another act on it when it pops). Chronos is accessed via an HTTP API.
+
+      - Memcached / Astaire. Vellum also runs a Memcached cluster fronted by Astaire. Astaire is a
+      service developed by Clearwater that enabled more rapid scale up and scale down of memcached
+      clusters. This cluster is used by Sprout and Ralf for storing registration and session state.
+    derived_from: clearwater.SoftwareComponent
+    capabilities:
+      cassandra_endpoint: cassandra.Endpoint # open to other Vellum
+      cassandra_thrift_endpoint: cassandra.Endpoint.Thrift # open to Homer, Dime (Homestead), Sprout (Memento)
+      chronos_endpoint: clearwater.Endpoint.Chronos # open to other Vellum, Sprout, Dime (Ralf)
+      memcached_endpoint: clearwater.Endpoint.Memcached # open to other Vellum
+      astaire_endpoint: clearwater.Endpoint.Astaire # open to Sprout, Dime (Ralf)
+# cyclical: see ARIA-327
+#    requirements:
+#      - ralf:
+#          capability: clearwater.Endpoint.Management.Ralf
+#          occurrences: [ 0, 1 ]       
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/vellum/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/vellum/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Homer:
+    description: >-
+      Clearwater XDMS.
+
+      Homer is a standard XDMS used to store MMTEL service settings documents for each user of the
+      system. Documents are created, read, updated and deleted using a standard XCAP interface. As
+      with Homestead, the Homer nodes use Vellum as the data store for all long lived data.
+    derived_from: clearwater.SoftwareComponent
+    capabilities:
+      xdms: ims.functions.XDMS
+      management_endpoint: clearwater.Endpoint.Management.Homer # open to Sprout, Ellis
+    requirements:
+      - cassandra_thrift:
+          capability: cassandra.Endpoint.Thrift
+          node: clearwater.Vellum
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/homer/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/homer/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.Ellis:
+    description: >-
+      Ellis is a sample provisioning portal providing self sign-up, password management, line
+      management and control of MMTEL service settings. It is not intended to be a part of
+      production Clearwater deployments (it is not easy to horizontally scale because of the MySQL
+      underpinnings for one thing) but to make the system easy to use out of the box.
+    derived_from: clearwater.SoftwareComponent
+    properties:
+      provision_numbers_start:
+        type: clearwater.Number
+        default: '6505550000'
+      provision_numbers_count:
+        type: integer
+        default: 0 # 0 means do not provision numbers
+        constraints:
+          - greater_or_equal: 0
+    capabilities:
+      web_endpoint: clearwater.Endpoint.Public.Web
+      web_secure_endpoint: clearwater.Endpoint.Public.Web.Secure
+    requirements:
+      - homer: # for subscriber profiles
+          capability: clearwater.Endpoint.Management.Homer
+      - homestead: # for subscriber authentication
+          capability: clearwater.Endpoint.Management.Homestead
+      - homestead_provisioning:
+          capability: clearwater.Endpoint.Management.Homestead.Provisioning
+      - ralf: # TODO: really?
+          capability: clearwater.Endpoint.Management.Ralf
+          occurrences: [ 0, 1 ]       
+      - smtp:
+          capability: smtp.SMTP
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/ellis/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        configure:
+          implementation:
+            primary: scripts/ellis/configure.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/ellis/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.I-CSCF:
+    description: >-
+      Clearwater I-CSCF.
+
+      Logical node encompassing Sprout and Homestead. Required only if you need to expose the I-CSCF
+      function.
+    derived_from: tosca.nodes.Root
+    capabilities:
+      i-cscf: ims.functions.I-CSCF
+    requirements:
+      - sprout:
+          capability: tosca.capabilities.Node
+          node: clearwater.Sprout
+      - homestead:
+          capability: tosca.capabilities.Node
+          node: clearwater.Homestead
+
+  clearwater.S-CSCF:
+    description: >-
+      Clearwater S-CSCF.
+
+      Logical node encompassing Sprout and Homestead. Required only if you need to expose the S-CSCF
+      function.
+    derived_from: tosca.nodes.Root
+    capabilities:
+      s-cscf: ims.functions.S-CSCF
+    requirements:
+      - sprout:
+          capability: tosca.capabilities.Node
+          node: clearwater.Sprout
+      - homestead:
+          capability: tosca.capabilities.Node
+          node: clearwater.Homestead
+
+  clearwater.LiveTest:
+    derived_from: tosca.nodes.SoftwareComponent
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        create:
+          implementation:
+            primary: scripts/live-test/create.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+        delete:
+          implementation:
+            primary: scripts/live-test/delete.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+
+  clearwater.HostBase:
+    derived_from: tosca.nodes.Compute
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        configure:
+          implementation:
+            primary: scripts/host-base/configure.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES
+    capabilities:
+      host: # override
+        type: clearwater.Container
+        valid_source_types: [ tosca.nodes.SoftwareComponent ]
+      os: # override
+        type: tosca.capabilities.OperatingSystem
+        properties:
+          architecture:
+            type: string
+            default: x86_64
+          type:
+            type: string
+            default: linux
+          distribution:
+            type: string
+            default: ubuntu
+          version:
+            type: version
+            default: 14.04
+
+  clearwater.Host:
+    description: >-
+      Default Clearwater host.
+
+      Note that any node can function as a Clearwater host as long as it has a clearwater.Container
+      capability.
+    derived_from: clearwater.HostBase
+    capabilities:
+      host: # override
+        type: clearwater.Container
+        valid_source_types: [ tosca.nodes.SoftwareComponent ]
+        properties:
+          mem_size:
+            type: scalar-unit.size
+            constraints:
+              - greater_or_equal: 0 MB
+            default: 4 GB # will run out of memory with less than this 
+    interfaces:
+      Standard:
+        type: tosca.interfaces.node.lifecycle.Standard
+        configure:
+          implementation:
+            primary: scripts/host/configure.sh
+            dependencies: *CLEARWATER_OPERATION_DEPENDENCIES

--- a/examples/clearwater/types/ims.yaml
+++ b/examples/clearwater/types/ims.yaml
@@ -1,0 +1,446 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+capability_types:
+
+  # https://en.wikipedia.org/wiki/IP_Multimedia_Subsystem#Core_network
+
+  ims.functions.Root:
+    derived_from: tosca.capabilities.Root
+
+  ims.functions.CTF: # not mentioned in Wikipedia
+    description: >-
+      Charging Trigger Function.
+    derived_from: ims.functions.Root
+
+  ims.functions.XDMS: # not mentioned in Wikipedia
+    description: >-
+      XML Document Management Server
+    derived_from: ims.functions.Root
+
+  ims.functions.HSS:
+    description: >-
+      The home subscriber server (HSS), or user profile server function (UPSF), is a master user
+      database that supports the IMS network entities that actually handle calls. It contains the
+      subscription-related information (subscriber profiles), performs authentication and
+      authorization of the user, and can provide information about the subscriber's location and IP
+      information. It is similar to the GSM home location register (HLR) and Authentication centre
+      (AuC).
+
+      A subscriber location function (SLF) is needed to map user addresses when multiple HSSs are
+      used.
+    derived_from: ims.functions.Root
+
+  ims.functions.CSCF:
+    description: >-
+      Several roles of SIP servers or proxies, collectively called Call Session Control Function
+      (CSCF), are used to process SIP signalling packets in the IMS.
+    derived_from: ims.functions.Root
+
+  ims.functions.P-CSCF:
+    description: >-
+      A Proxy-CSCF (P-CSCF) is a SIP proxy that is the first point of contact for the IMS terminal.
+      It can be located either in the visited network (in full IMS networks) or in the home network
+      (when the visited network is not IMS compliant yet). Some networks may use a Session Border
+      Controller (SBC) for this function. The P-CSCF is at its core a specialized SBC for the
+      User–network interface which not only protects the network, but also the IMS terminal. The use
+      of an additional SBC between the IMS terminal and the P-CSCF is unnecessary and infeasible due
+      to the signaling being encrypted on this leg. The terminal discovers its P-CSCF with either
+      DHCP, or it may be configured (e.g. during initial provisioning or via a 3GPP IMS Management
+      Object (MO)) or in the ISIM or assigned in the PDP Context (in General Packet Radio Service
+      (GPRS)).
+    derived_from: ims.functions.CSCF
+
+  ims.functions.I-CSCF:
+    description: >-
+      An Interrogating-CSCF (I-CSCF) is another SIP function located at the edge of an
+      administrative domain. Its IP address is published in the Domain Name System (DNS) of the
+      domain (using NAPTR and SRV type of DNS records), so that remote servers can find it, and use
+      it as a forwarding point (e.g., registering) for SIP packets to this domain.
+    derived_from: ims.functions.CSCF
+
+  ims.functions.S-CSCF:
+    description: >-
+      A Serving-CSCF (S-CSCF) is the central node of the signalling plane. It is a SIP server, but
+      performs session control too. It is always located in the home network. It uses Diameter Cx
+      and Dx interfaces to the HSS to download user profiles and upload user-to-S-CSCF associations
+      (the user profile is only cached locally for processing reasons only and is not changed). All
+      necessary subscriber profile information is loaded from the HSS.
+    derived_from: ims.functions.CSCF
+
+  ims.functions.AS:
+    description: >-
+      SIP Application servers (AS) host and execute services, and interface with the S-CSCF using
+      SIP. An example of an application server that is being developed in 3GPP is the Voice call
+      continuity Function (VCC Server). Depending on the actual service, the AS can operate in SIP
+      proxy mode, SIP UA (user agent) mode or SIP B2BUA mode. An AS can be located in the home
+      network or in an external third-party network. If located in the home network, it can query
+      the HSS with the Diameter Sh or Si interfaces (for a SIP-AS).
+    derived_from: ims.functions.Root
+
+  ims.functions.SIP-AS:
+    description: >-
+      Host and execute IMS specific services.
+    derived_from: ims.functions.AS
+
+  ims.functions.IM-SSF:
+    description: >-
+      IP Multimedia Service Switching Function. Interfaces SIP to CAP to communicate with CAMEL
+      Application Servers.
+    derived_from: ims.functions.AS
+
+  ims.functions.OSA-SCS:
+    description: >-
+      OSA service capability server. Interfaces SIP to the OSA framework.
+    derived_from: ims.functions.AS
+
+  ims.functions.AS-ILCM:
+    description: >-
+      The AS-ILCM (Application Server - Incoming Leg Control Model) stores transaction state, and
+      may optionally store session state depending on the specific service being executed. The
+      AS-ILCM interfaces to the S-CSCF (ILCM) for an incoming leg. Application Logic provides the
+      service(s) and interacts between the AS-ILCM and AS-OLCM.
+    derived_from: ims.functions.AS
+
+  ims.functions.AS-OLCM:
+    description: >-
+      The AS-OLCM (Application Server - Outgoing Leg Control Model) stores transaction state, and
+      may optionally store session state depending on the specific service being executed. The
+      AS-OLCM interfaces to the S-CSCF (OLCM) for an outgoing leg. Application Logic provides the
+      service(s) and interacts between the AS-ILCM and AS-OLCM.
+    derived_from: ims.functions.AS
+
+  ims.functions.MRF:
+    description: >-
+      The Media Resource Function (MRF) provides media related functions such as media manipulation
+      (e.g. voice stream mixing) and playing of tones and announcements.
+
+      Each MRF is further divided into a media resource function controller (MRFC) and a media
+      resource function processor (MRFP).
+    derived_from: ims.functions.Root
+
+  ims.functions.MRFC:
+    description: >-
+      The MRFC is a signalling plane node that interprets information coming from an AS and S-CSCF
+      to control the MRFP.
+    derived_from: ims.functions.Root
+
+  ims.functions.MRFP:
+    description: >-
+      The MRFP is a media plane node used to mix, source or process media streams. It can also
+      manage access right to shared resources.
+    derived_from: ims.functions.Root
+
+  ims.functions.MRB:
+    description: >-
+      The Media Resource Broker (MRB) is a functional entity that is responsible for both collection
+      of appropriate published MRF information and supplying of appropriate MRF information to
+      consuming entities such as the AS. MRB can be used in two modes:
+      * Query mode: AS queries the MRB for media and sets up the call using the response of MRB
+      * In-Line Mode: AS sends a SIP INVITE to the MRB. The MRB sets up the call
+    derived_from: ims.functions.Root
+
+  ims.functions.BGCF:
+    description: >-
+      A Breakout Gateway Control Function (BGCF) is a SIP proxy which processes requests for routing
+      from an S-CSCF when the S-CSCF has determined that the session cannot be routed using DNS or
+      ENUM/DNS. It includes routing functionality based on telephone numbers.
+    derived_from: ims.functions.Root
+
+  ims.functions.PTSNGateway:
+    description: >-
+      A PSTN/CS gateway interfaces with PSTN circuit switched (CS) networks. For signalling, CS
+      networks use ISDN User Part (ISUP) (or BICC) over Message Transfer Part (MTP), while IMS uses
+      SIP over IP. For media, CS networks use Pulse-code modulation (PCM), while IMS uses Real-time
+      Transport Protocol (RTP).
+    derived_from: ims.functions.Root
+
+  ims.functions.SGW:
+    description: >-
+      A signalling gateway (SGW) interfaces with the signalling plane of the CS. It transforms lower
+      layer protocols as Stream Control Transmission Protocol (SCTP, an IP protocol) into Message
+      Transfer Part (MTP, an Signalling System 7 (SS7) protocol), to pass ISDN User Part (ISUP) from
+      the MGCF to the CS network.
+    derived_from: ims.functions.PTSNGateway
+
+  ims.functions.MGCF:
+    description: >-
+      A media gateway controller function (MGCF) is a SIP endpoint that does call control protocol
+      conversion between SIP and ISUP/BICC and interfaces with the SGW over SCTP. It also controls
+      the resources in a Media Gateway (MGW) across an H.248 interface.
+    derived_from: ims.functions.PTSNGateway
+
+  ims.functions.MGW:
+    description: >-
+      A media gateway (MGW) interfaces with the media plane of the CS network, by converting between
+      RTP and PCM. It can also transcode when the codecs don't match (e.g., IMS might use AMR, PSTN
+      might use G.711).
+    derived_from: ims.functions.PTSNGateway
+
+  # https://en.wikipedia.org/wiki/IP_Multimedia_Subsystem#Interfaces_description
+
+  ims.interfaces.Diameter:
+    derived_from: tosca.capabilities.Endpoint
+
+  ims.interfaces.TCP:
+    derived_from: tosca.capabilities.Endpoint
+
+  ims.interfaces.SIP:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: sip
+
+  ims.interfaces.RTP:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: rtp
+
+  ims.interfaces.H248:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: h248
+
+  ims.interfaces.HTTP:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: http
+
+  ims.interfaces.MAP:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      protocol: # override
+        type: string
+        default: map
+
+  ims.interfaces.Cr:
+    description: >-
+      Used by MRFC to fetch documents (e.g. scripts, announcement files, and other resources) from
+      an AS. Also used for media control related commands.
+    derived_from: ims.interfaces.TCP
+
+  ims.interfaces.Cx:
+    description: >-
+      Used to send subscriber data to the S-CSCF; including filter criteria and their priority. Also
+      used to furnish CDF and/or OCF addresses.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Dh:
+    description: >-
+      Used by AS to find the HSS holding the user profile information in a multi-HSS environment.
+      DH_SLF_QUERY indicates an IMPU and DX_SLF_RESP return the HSS name.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Dx:
+    description: >-
+      Used by I-CSCF or S-CSCF to find a correct HSS in a multi-HSS environment. DX_SLF_QUERY
+      indicates an IMPU and DX_SLF_RESP return the HSS name.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Gm:
+    description: >-
+      Used to exchange messages between SIP user equipment (UE) or Voip gateway and P-CSCF.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Go:
+    description: >-
+      Allows operators to control QoS in a user plane and exchange charging correlation
+      information between IMS and GPRS network.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Gq:
+    description: >-
+      Used to exchange policy decisions-related information between P-CSCF and PDF.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Gx:
+    description: >-
+      Used to exchange policy decisions-related information between PCEF and PCRF.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Gy:
+    description: >-
+      Used for online flow-based bearer charging. Functionally equivalent to Ro interface.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.ISC:
+    description: >-
+      Reference point between S-CSCF and AS. Main functions are to:
+      * Notify the AS of the registered IMPU, registration state and UE capabilities
+      * Supply the AS with information to allow it to execute multiple services
+      * Convey charging function addresses
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Ici:
+    description: >-
+      Used to exchange messages between an IBCF and another IBCF belonging to a different IMS
+      network.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Izi:
+    description: >-
+      Used to forward media streams from a TrGW to another TrGW belonging to a different IMS
+      network.
+    derived_from: ims.interfaces.RTP
+
+  ims.interfaces.Ma:
+    description: >-
+      Main functions are to:
+      * Forward SIP requests which are destined to a public service identity hosted by the AS
+      * Originate a session on behalf of a user or public service identity, if the AS has no
+        knowledge of a S-CSCF assigned to that user or public service identity
+      * Convey charging function addresses
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mg:
+    description: >-
+      ISUP signalling to SIP signalling and forwards SIP signalling to I-CSCF.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mi:
+    description: >-
+      Used to exchange messages between S-CSCF and BGCF.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mj:
+    description: >-
+      Used for the interworking with the PSTN/CS domain, when the BGCF has determined that a
+      breakout should occur in the same IMS network to send SIP message from BGCF to MGCF.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mk:
+    description: >-
+      Used for the interworking with the PSTN/CS domain, when the BGCF has determined that a
+      breakout should occur in another IMS network to send SIP message from BGCF to the BGCF in the
+      other network.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mm:
+    description: >-
+      Used for exchanging messages between IMS and external IP networks.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mn:
+    description: >-
+      Allows control of user-plane resources.
+    derived_from: ims.interfaces.H248
+
+  ims.interfaces.Mp:
+    description: >-
+      Allows an MRFC to control media stream resources provided by an MRFP.
+    derived_from: ims.interfaces.H248
+
+  ims.interfaces.Mr:
+    description: >-
+      Used to exchange information between S-CSCF and MRFC.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mr2:
+    description: >-
+      Used to exchange session controls between AS and MRFC.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mw:
+    description: >-
+      Used to exchange messages between CSCFs. AGCF appears as a P-CSCF to the other CSCFs.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Mx:
+    description: >-
+      Used for the interworking with another IMS network, when the BGCF has determined that a
+      breakout should occur in the other IMS network to send SIP message from BGCF to the IBCF in
+      the other network.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.P1:
+    description: >-
+      Used for call control services by AGCF to control H.248 A-MGW and residential gateways.
+    derived_from: ims.interfaces.H248
+
+  ims.interfaces.P2:
+    description: >-
+      Reference point between AGCF and CSCF.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Rc:
+    description: >-
+      Used by the AS to request that media resources be assigned to a call when using MRB in-line
+      mode or in query mode.
+    derived_from: ims.interfaces.SIP
+
+  ims.interfaces.Rf:
+    description: >-
+      Used to exchange offline charging information with CDF.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Ro:
+    description: >-
+        Used to exchange online charging information with OCF.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Rx:
+    description: >-
+      Used to exchange policy and charging related information between P-CSCF and PCRF. Replacement
+      for the Gq reference point.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Sh:
+    description: >-
+      Used to exchange User Profile information (e.g., user-related data, group lists,
+      user-service-related information or user location information or charging function addresses
+      (used when the AS has not received the third-party REGISTER for a user)) between an AS (SIP
+      AS or OSA SCS) and HSS. Also allow AS to activate/deactivate filter criteria stored in the HSS
+      on a per-subscriber basis.
+    derived_from: ims.interfaces.Diameter
+
+  ims.interfaces.Si:
+    description: >-
+      Transports CAMEL subscription information, including triggers for use by CAMEL-based
+      application services information.
+    derived_from: ims.interfaces.MAP
+
+  ims.interfaces.Sr:
+    description: >-
+      Used by MRFC to fetch documents (scripts and other resources) from an AS.
+    derived_from: ims.interfaces.HTTP
+
+  ims.interfaces.Ut:
+    description: >-
+      Facilitates the management of subscriber information related to services and settings.
+    derived_from: ims.interfaces.HTTP
+
+  ims.interfaces.Z:
+    description: >-
+      Conversion of POTS services to SIP messages.
+    derived_from: tosca.capabilities.Root
+
+node_types:
+
+  ims.nodes.IMS:
+    derived_from: tosca.nodes.Root
+    capabilities:
+      p-cscf: ims.functions.P-CSCF
+      i-cscf: ims.functions.I-CSCF
+      s-cscf: ims.functions.S-CSCF
+      hss: ims.functions.HSS
+      ctf: ims.functions.CTF
+      xdms: ims.functions.XDMS

--- a/examples/clearwater/types/smtp.yaml
+++ b/examples/clearwater/types/smtp.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+capability_types:
+
+  smtp.SMTP:
+    derived_from: tosca.capabilities.Root
+    properties:
+      username:
+        type: string
+      password:
+        type: string
+
+node_types:
+
+  smtp.SMTP:
+    derived_from: tosca.nodes.SoftwareComponent
+    properties:
+      address:
+        type: string
+    capabilities:
+      smtp:
+        type: smtp.SMTP

--- a/examples/hello-world/hello-world.yaml
+++ b/examples/hello-world/hello-world.yaml
@@ -6,10 +6,10 @@ node_types:
     derived_from: tosca:Root
     capabilities:
       host:
-        type: tosca.capabilities.Container
+        type: tosca:Container
 
   WebApp:
-    derived_from: tosca.nodes.WebApplication
+    derived_from: tosca:WebApplication
     properties:
       port:
         type: integer

--- a/examples/tosca-simple-1.0/use-cases/block-storage-1/block-storage-1.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-1/block-storage-1.yaml
@@ -24,7 +24,7 @@ topology_template:
     storage_snapshot_id:
       type: string
       description: >-
-        Optional identifier for an existing snapshot to use when creating storage.    
+        Optional identifier for an existing snapshot to use when creating storage.
     storage_location:
       type: string
       description: Block storage mount point (filesystem path).
@@ -42,8 +42,8 @@ topology_template:
         os:
           properties:
             architecture: x86_64
-            type: linux 
-            distribution: fedora 
+            type: linux
+            distribution: fedora
             version: 18.0
       requirements:
         - local_storage:

--- a/examples/tosca-simple-1.0/use-cases/block-storage-2/block-storage-2.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-2/block-storage-2.yaml
@@ -29,7 +29,7 @@ topology_template:
     storage_snapshot_id:
       type: string
       description: >-
-        Optional identifier for an existing snapshot to use when creating storage.    
+        Optional identifier for an existing snapshot to use when creating storage.
     storage_location:
       type: string
       description: Block storage mount point (filesystem path).
@@ -47,8 +47,8 @@ topology_template:
         os:
           properties:
             architecture: x86_64
-            type: Linux 
-            distribution: Fedora 
+            type: Linux
+            distribution: Fedora
             version: 18.0
       requirements:
         - local_storage:

--- a/examples/tosca-simple-1.0/use-cases/block-storage-3/block-storage-3.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-3/block-storage-3.yaml
@@ -38,8 +38,8 @@ topology_template:
         os:
           properties:
             architecture: x86_64
-            type: Linux 
-            distribution: Fedora 
+            type: Linux
+            distribution: Fedora
             version: 18.0
       requirements:
         - local_storage:

--- a/examples/tosca-simple-1.0/use-cases/block-storage-4/block-storage-4.yaml
+++ b/examples/tosca-simple-1.0/use-cases/block-storage-4/block-storage-4.yaml
@@ -33,7 +33,7 @@ topology_template:
     storage_snapshot_id:
       type: string
       description: >-
-        Optional identifier for an existing snapshot to use when creating storage.    
+        Optional identifier for an existing snapshot to use when creating storage.
 
   node_templates:
 

--- a/examples/tosca-simple-1.0/use-cases/non-normative-types.yaml
+++ b/examples/tosca-simple-1.0/use-cases/non-normative-types.yaml
@@ -50,7 +50,7 @@ capability_types:
         required: false
       publish_ports:
         description: >-
-          List of ports mappings from source (Docker container) to target (host) ports to publish. 
+          List of ports mappings from source (Docker container) to target (host) ports to publish.
         type: list
         entry_schema: PortSpec
         required: false
@@ -118,7 +118,7 @@ node_types:
       # Further constrain the 'host' capability to only allow MySQL databases
       host:
         type: tosca.capabilities.Container # ARIA NOTE: missing in spec
-        valid_source_types: [ tosca.nodes.Database.MySQL ] 
+        valid_source_types: [ tosca.nodes.Database.MySQL ]
 
   tosca.nodes.WebServer.Apache:
     _extensions:
@@ -143,7 +143,7 @@ node_types:
         required: false # ARIA NOTE: missing in spec
     requirements:
       - database_endpoint:
-          capability: tosca.capabilities.Endpoint.Database  
+          capability: tosca.capabilities.Endpoint.Database
           node: tosca.nodes.Database
           relationship: tosca.relationships.ConnectsTo
 

--- a/examples/tosca-simple-1.0/use-cases/webserver-dbms-1/webserver-dbms-1.yaml
+++ b/examples/tosca-simple-1.0/use-cases/webserver-dbms-1/webserver-dbms-1.yaml
@@ -51,11 +51,11 @@ topology_template:
         Standard:
           create: wordpress_install.sh
           configure:
-            implementation: wordpress_configure.sh           
+            implementation: wordpress_configure.sh
             inputs:
               wp_db_name: { get_property: [ mysql_database, name ] }
               wp_db_user: { get_property: [ mysql_database, user ] }
-              wp_db_password: { get_property: [ mysql_database, password ] }  
+              wp_db_password: { get_property: [ mysql_database, password ] }
               # In my own template, find requirement/capability, find port property
               wp_db_port: { get_property: [ SELF, database_endpoint, port ] }
 
@@ -85,7 +85,7 @@ topology_template:
         - host: server
       interfaces:
         Standard:
-          # ARIA NOTE: not declared in spec              
+          # ARIA NOTE: not declared in spec
           #inputs:
           #  db_root_password: { get_property: [ mysql_dbms, root_password ] }
           create: mysql_dbms_install.sh
@@ -112,8 +112,8 @@ topology_template:
         os:
           properties:
             architecture: x86_64
-            type: linux 
-            distribution: fedora 
+            type: linux
+            distribution: fedora
             version: 17.0
 
   outputs:

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/artifacts.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/artifacts.yaml
@@ -24,7 +24,7 @@ artifact_types:
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_ARTIFACTS_ROOT'
     description: >-
       This is the default (root) TOSCA Artifact Type definition that all other TOSCA base Artifact Types derive from.
-  
+
   tosca.artifacts.File:
     _extensions:
       shorthand_name: File
@@ -34,11 +34,11 @@ artifact_types:
     description: >-
       This artifact type is used when an artifact definition needs to have its associated file simply treated as a file and no special handling/handlers are invoked (i.e., it is not treated as either an implementation or deployment artifact type).
     derived_from: tosca.artifacts.Root
-  
+
   #
   # Deployments
   #
-  
+
   tosca.artifacts.Deployment:
     _extensions:
       shorthand_name: Deployment # ARIA NOTE: omitted in the spec
@@ -51,7 +51,7 @@ artifact_types:
       represents a binary packaging of an application or service that is used to install/create or deploy it as part of a node's
       lifecycle.
     derived_from: tosca.artifacts.Root
-    
+
   tosca.artifacts.Deployment.Image:
     _extensions:
       shorthand_name: Deployment.Image
@@ -64,7 +64,7 @@ artifact_types:
       (whether real or virtual) whose contents are typically already installed and pre-configured (i.e., "stateful") and prepared
       to be run on a known target container.
     derived_from: tosca.artifacts.Deployment
-  
+
   tosca.artifacts.Deployment.Image.VM:
     _extensions:
       shorthand_name: Deployment.VM # ARIA NOTE: omitted in the spec
@@ -78,11 +78,11 @@ artifact_types:
       with any configurations and can be run on another machine using a hypervisor which virtualizes typical server (i.e.,
       hardware) resources.
     derived_from: tosca.artifacts.Deployment
-  
+
   #
   # Implementations
   #
-  
+
   tosca.artifacts.Implementation:
     _extensions:
       shorthand_name: Implementation # ARIA NOTE: omitted in the spec
@@ -94,7 +94,7 @@ artifact_types:
       This artifact type represents the parent type for all implementation artifacts in TOSCA. These artifacts are used to
       implement operations of TOSCA interfaces either directly (e.g., scripts) or indirectly (e.g., config. files).
     derived_from: tosca.artifacts.Root
-  
+
   tosca.artifacts.Implementation.Bash:
     _extensions:
       shorthand_name: Implementation.Bash # ARIA NOTE: mistake in spec? shouldn't we have "Implementation." as prefix?
@@ -106,7 +106,7 @@ artifact_types:
     derived_from: tosca.artifacts.Implementation
     mime_type: application/x-sh
     file_ext: [ sh ]
-  
+
   tosca.artifacts.Implementation.Python:
     _extensions:
       shorthand_name: Implementation.Python # ARIA NOTE: mistake in spec? shouldn't we have "Implementation." as prefix?

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/capabilities.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/capabilities.yaml
@@ -51,7 +51,7 @@ capability_types:
     derived_from: tosca.capabilities.Root
     properties:
       num_cpus:
-        description: >-    
+        description: >-
           Number of (actual or virtual) CPUs associated with the Compute node.
         type: integer
         constraints:
@@ -239,7 +239,7 @@ capability_types:
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_CAPABILITIES_ENDPOINT_PUBLIC'
     description: >-
       This capability represents a public endpoint which is accessible to the general internet (and its public IP address ranges).
-  
+
       This public endpoint capability also can be used to create a floating (IP) address that the underlying network assigns from a
       pool allocated from the application's underlying public network. This floating address is managed by the underlying network
       such that can be routed an application's private address and remains reliable to internet clients.
@@ -292,14 +292,14 @@ capability_types:
     description: >-
       This is the default TOSCA type that should be used or extended to define a specialized database endpoint capability.
     derived_from: tosca.capabilities.Endpoint
-  
+
   #
   # Network
   #
 
   tosca.capabilities.network.Bindable:
     _extensions:
-      shorthand_name: Bindable # ARIA NOTE: mistake in spec? has "network." as a prefix 
+      shorthand_name: Bindable # ARIA NOTE: mistake in spec? has "network." as a prefix
       type_qualified_name: tosca:Bindable
       specification: tosca-simple-1.0
       specification_section: 5.4.11

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/data.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/data.yaml
@@ -18,7 +18,7 @@ data_types:
   #
   # Primitive
   #
-  
+
   timestamp:
     _extensions:
       coerce_value: aria_extension_tosca.simple_v1_0.data_types.coerce_timestamp
@@ -60,7 +60,7 @@ data_types:
       specification: tosca-simple-1.0
       specification_section: 3.2.5
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#TYPE_TOSCA_MAP'
-  
+
   #
   # Scalar
   #
@@ -142,7 +142,7 @@ data_types:
           The optional user (name or ID) used for non-token based credentials.
         type: string
         required: false
-  
+
   tosca.datatypes.network.NetworkInfo:
     _extensions:
       shorthand_name: NetworkInfo
@@ -171,7 +171,7 @@ data_types:
         entry_schema:
           type: string
         required: false
-  
+
   tosca.datatypes.network.PortInfo:
     _extensions:
       shorthand_name: PortInfo
@@ -210,7 +210,7 @@ data_types:
         entry_schema:
           type: string
         required: false
-  
+
   tosca.datatypes.network.PortDef:
     _extensions:
       shorthand_name: PortDef

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/interfaces.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/interfaces.yaml
@@ -24,7 +24,7 @@ interface_types:
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#_Ref384391055'
     description: >-
       This is the default (root) TOSCA Interface Type definition that all other TOSCA Interface Types derive from.
-  
+
   tosca.interfaces.node.lifecycle.Standard:
     _extensions:
       shorthand_name: Standard

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/nodes.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/nodes.yaml
@@ -45,14 +45,14 @@ node_types:
         type: tosca.interfaces.node.lifecycle.Standard
     capabilities:
       feature:
-        type: tosca.capabilities.Node  
+        type: tosca.capabilities.Node
     requirements:
       - dependency:
           capability: tosca.capabilities.Node
           node: tosca.nodes.Root
           relationship: tosca.relationships.DependsOn
           occurrences: [ 0, UNBOUNDED ]
-  
+
   tosca.nodes.Compute:
     _extensions:
       shorthand_name: Compute
@@ -133,11 +133,11 @@ node_types:
           capability: tosca.capabilities.Endpoint
           relationship: tosca.relationships.RoutesTo
           occurrences: [ 0, UNBOUNDED ]
-  
+
   #
   # Software
   #
-  
+
   tosca.nodes.SoftwareComponent:
     _extensions:
       shorthand_name: SoftwareComponent
@@ -211,7 +211,7 @@ node_types:
           capability: tosca.capabilities.Container
           node: tosca.nodes.WebServer
           relationship: tosca.relationships.HostedOn
-  
+
   tosca.nodes.DBMS:
     _extensions:
       shorthand_name: DBMS # ARIA NOTE: omitted in the spec
@@ -276,7 +276,7 @@ node_types:
           capability: tosca.capabilities.Container
           node: tosca.nodes.DBMS
           relationship: tosca.relationships.HostedOn
-  
+
   #
   # Container
   #
@@ -351,7 +351,7 @@ node_types:
     capabilities:
       storage_endpoint:
         type: tosca.capabilities.Endpoint
-  
+
   tosca.nodes.BlockStorage:
     _extensions:
       shorthand_name: BlockStorage
@@ -463,7 +463,7 @@ node_types:
     capabilities:
       link:
         type: tosca.capabilities.network.Linkable
-  
+
   tosca.nodes.network.Port:
     _extensions:
       shorthand_name: Port
@@ -472,7 +472,7 @@ node_types:
       specification_section: 7.5.2
     description: >-
       The TOSCA Port node represents a logical entity that associates between Compute and Network normative types.
-      
+
       The Port node type effectively represents a single virtual NIC on the Compute node instance.
     derived_from: tosca.nodes.Root
     properties:

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/policies.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/policies.yaml
@@ -24,7 +24,7 @@ policy_types:
       specification_url: 'http://docs.oasis-open.org/tosca/TOSCA-Simple-Profile-YAML/v1.0/cos01/TOSCA-Simple-Profile-YAML-v1.0-cos01.html#DEFN_TYPE_POLICIES_ROOT'
     description: >-
       This is the default (root) TOSCA Policy Type definition that all other TOSCA base Policy Types derive from.
-  
+
   tosca.policies.Placement:
     _extensions:
       shorthand_name: Placement # ARIA NOTE: omitted in the spec
@@ -35,7 +35,7 @@ policy_types:
     description: >-
       This is the default (root) TOSCA Policy Type definition that is used to govern placement of TOSCA nodes or groups of nodes.
     derived_from: tosca.policies.Root
-  
+
   tosca.policies.Scaling:
     _extensions:
       shorthand_name: Scaling # ARIA NOTE: omitted in the spec
@@ -46,7 +46,7 @@ policy_types:
     description: >-
       This is the default (root) TOSCA Policy Type definition that is used to govern scaling of TOSCA nodes or groups of nodes.
     derived_from: tosca.policies.Root
-  
+
   tosca.policies.Update:
     _extensions:
       shorthand_name: Update # ARIA NOTE: omitted in the spec
@@ -57,7 +57,7 @@ policy_types:
     description: >-
       This is the default (root) TOSCA Policy Type definition that is used to govern update of TOSCA nodes or groups of nodes.
     derived_from: tosca.policies.Root
-  
+
   tosca.policies.Performance:
     _extensions:
       shorthand_name: Performance # ARIA NOTE: omitted in the spec

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/relationships.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-1.0/relationships.yaml
@@ -43,7 +43,7 @@ relationship_types:
     interfaces:
       Configure:
         type: tosca.interfaces.relationship.Configure
-  
+
   tosca.relationships.DependsOn:
     _extensions:
       shorthand_name: DependsOn
@@ -55,7 +55,7 @@ relationship_types:
       This type represents a general dependency relationship between two nodes.
     derived_from: tosca.relationships.Root
     valid_target_types: [ tosca.capabilities.Node ]
-  
+
   tosca.relationships.HostedOn:
     _extensions:
       shorthand_name: HostedOn
@@ -67,7 +67,7 @@ relationship_types:
       This type represents a hosting relationship between two nodes.
     derived_from: tosca.relationships.Root
     valid_target_types: [ tosca.capabilities.Container ]
-  
+
   tosca.relationships.ConnectsTo:
     _extensions:
       shorthand_name: ConnectsTo
@@ -83,7 +83,7 @@ relationship_types:
       credential:
         type: tosca.datatypes.Credential
         required: false
-  
+
   tosca.relationships.AttachesTo:
     _extensions:
       shorthand_name: AttachesTo
@@ -116,7 +116,7 @@ relationship_types:
           The logical name of the device as exposed to the instance.
           Note: A runtime property that gets set when the model gets instantiated by the orchestrator.
         type: string
-  
+
   tosca.relationships.RoutesTo:
     _extensions:
       shorthand_name: RoutesTo
@@ -128,11 +128,11 @@ relationship_types:
       This type represents an intentional network routing between two Endpoints in different networks.
     derived_from: tosca.relationships.ConnectsTo
     valid_target_types: [ tosca.capabilities.Endpoint ]
-  
+
   #
   # Network
   #
-  
+
   tosca.relationships.network.LinksTo:
     _extensions:
       shorthand_name: LinksTo
@@ -144,7 +144,7 @@ relationship_types:
       This relationship type represents an association relationship between Port and Network node types.
     derived_from: tosca.relationships.DependsOn
     valid_target_types: [ tosca.capabilities.network.Linkable ]
-  
+
   tosca.relationships.network.BindsTo:
     _extensions:
       shorthand_name: BindsTo # ARIA NOTE: the spec says "network.BindsTo" which seems wrong

--- a/extensions/aria_extension_tosca/profiles/tosca-simple-nfv-1.0/nodes.yaml
+++ b/extensions/aria_extension_tosca/profiles/tosca-simple-nfv-1.0/nodes.yaml
@@ -98,11 +98,11 @@ node_types:
         # ARIA NOTE: commented out in 5.9.2.5
         description: >-
           Monitoring parameter, which can be tracked for a VNFC based on this VDU. Examples include:
-          memory-consumption, CPU-utilisation, bandwidth-consumption, VNFC downtime, etc.        
+          memory-consumption, CPU-utilisation, bandwidth-consumption, VNFC downtime, etc.
         type: tosca.capabilities.nfv.Metric
     #requirements:
       # ARIA NOTE: virtual_storage is TBD
-      
+
       # ARIA NOTE: csd04 attempts to deprecate the inherited local_storage requirement, but this
       # is not possible in TOSCA
     artifacts:

--- a/extensions/aria_extension_tosca/simple_v1_0/assignments.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/assignments.py
@@ -363,7 +363,7 @@ class CapabilityAssignment(ExtensiblePresentation):
 
 @has_fields
 @implements_specification('3.5.6', 'tosca-simple-1.0')
-class ArtifactAssignment(ExtensiblePresentation):
+class ArtifactAssignmentForType(ExtensiblePresentation):
     """
     An artifact definition defines a named, typed file that can be associated with Node Type or Node
     Template and used by orchestration engine to facilitate deployment and implementation of
@@ -441,6 +441,12 @@ class ArtifactAssignment(ExtensiblePresentation):
     def _get_property_values(self, context):
         return FrozenDict(get_assigned_and_defined_parameter_values(context, self, 'property'))
 
+    @cachedmethod
+    def _validate(self, context):
+        super(ArtifactAssignmentForType, self)._validate(context)
+
+
+class ArtifactAssignment(ArtifactAssignmentForType):
     @cachedmethod
     def _validate(self, context):
         super(ArtifactAssignment, self)._validate(context)

--- a/extensions/aria_extension_tosca/simple_v1_0/data_types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/data_types.py
@@ -163,7 +163,7 @@ class Version(object):
     #TYPE_TOSCA_VERSION>`__
     """
 
-    REGULAR = \
+    REGEX = \
         r'^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<fix>\d+)' + \
         r'((\.(?P<qualifier>\d+))(\-(?P<build>\d+))?)?)?$'
 
@@ -176,7 +176,7 @@ class Version(object):
 
     def __init__(self, entry_schema, constraints, value, aspect): # pylint: disable=unused-argument
         str_value = str(value)
-        match = re.match(Version.REGULAR, str_value)
+        match = re.match(Version.REGEX, str_value)
         if match is None:
             raise ValueError(
                 'version must be formatted as <major_version>.<minor_version>'
@@ -376,11 +376,14 @@ class Scalar(object):
 
     def __init__(self, entry_schema, constraints, value, aspect): # pylint: disable=unused-argument
         str_value = str(value)
-        match = re.match(self.REGULAR, str_value) # pylint: disable=no-member
+        match = re.match(self.REGEX, str_value) # pylint: disable=no-member
         if match is None:
             raise ValueError('scalar must be formatted as <scalar> <unit>: %s' % safe_repr(value))
 
         self.factor = float(match.group('scalar'))
+        if self.factor < 0:
+            raise ValueError('scalar is negative: %s' % safe_repr(self.factor))
+
         self.unit = match.group('unit')
 
         unit_lower = self.unit.lower()
@@ -435,7 +438,7 @@ class ScalarSize(Scalar):
     """
 
     # See: http://www.regular-expressions.info/floatingpoint.html
-    REGULAR = \
+    REGEX = \
         r'^(?P<scalar>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*(?P<unit>B|kB|KiB|MB|MiB|GB|GiB|TB|TiB)$'
 
     UNITS = {
@@ -464,7 +467,7 @@ class ScalarTime(Scalar):
     """
 
     # See: http://www.regular-expressions.info/floatingpoint.html
-    REGULAR = r'^(?P<scalar>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*(?P<unit>ns|us|ms|s|m|h|d)$'
+    REGEX = r'^(?P<scalar>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*(?P<unit>ns|us|ms|s|m|h|d)$'
 
     UNITS = {
         'ns':     0.000000001,
@@ -490,7 +493,7 @@ class ScalarFrequency(Scalar):
     """
 
     # See: http://www.regular-expressions.info/floatingpoint.html
-    REGULAR = r'^(?P<scalar>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*(?P<unit>Hz|kHz|MHz|GHz)$'
+    REGEX = r'^(?P<scalar>[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?)\s*(?P<unit>Hz|kHz|MHz|GHz)$'
 
     UNITS = {
         'Hz':           1.0,

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/capabilities.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/capabilities.py
@@ -68,12 +68,14 @@ def get_inherited_capability_definitions(context, presentation, for_presentation
                 capability_definition = capability_definitions[capability_name]
 
                 # Check if we changed the type
-                type1 = capability_definition.type
-                type2 = our_capability_definition.type
-                if type1 != type2:
+                type1 = capability_definition._get_type(context)
+                type2 = our_capability_definition._get_type(context)
+
+                if not type1._is_descendant(context, type2):
                     context.validation.report(
-                        'capability definition changes type from "{0}" to "{1}" in "{2}"'
-                        .format(type1, type2, presentation._fullname),
+                        'capability definition type "{0}" is not a descendant of overridden '
+                        'capability definition type "{1}"' \
+                        .format(type1._name, type2._name),
                         locator=our_capability_definition._locator, level=Issue.BETWEEN_TYPES)
 
                 merge_capability_definition(context, presentation, capability_definition,
@@ -167,6 +169,8 @@ def convert_capability_from_definition_to_assignment(context, presentation, cont
 def merge_capability_definition(context, presentation, capability_definition,
                                 from_capability_definition):
     raw_properties = OrderedDict()
+
+    capability_definition._raw['type'] = from_capability_definition.type
 
     # Merge properties from type
     from_property_defintions = from_capability_definition.properties

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/data_types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/data_types.py
@@ -159,10 +159,6 @@ def get_data_type(context, presentation, field_name, allow_none=False):
         else:
             return str
 
-    # Make sure not derived from self
-    if type_name == presentation._name:
-        return None
-
     # Avoid circular definitions
     container_data_type = get_container_data_type(presentation)
     if (container_data_type is not None) and (container_data_type._name == type_name):

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/functions.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/functions.py
@@ -200,20 +200,24 @@ class GetProperty(Function):
         for modelable_entity in modelable_entities:
             properties = None
 
+            # First argument refers to a requirement template?
             if hasattr(modelable_entity, 'requirement_templates') \
                 and modelable_entity.requirement_templates \
                 and (req_or_cap_name in [v.name for v in modelable_entity.requirement_templates]):
-                for requirement_template in modelable_entity.requirement_templates:
-                    if requirement_template.name == req_or_cap_name:
-                        # First argument refers to a requirement
-                        # TODO: should follow to matched capability in other node...
+                for requirement in modelable_entity.requirement_templates:
+                    if requirement.name == req_or_cap_name:
+                        # TODO
                         raise CannotEvaluateFunctionException()
-                        # break
+            # First argument refers to a capability?
+            elif hasattr(modelable_entity, 'capabilities') \
+                and modelable_entity.capabilities \
+                and (req_or_cap_name in modelable_entity.capabilities):
+                properties = modelable_entity.capabilities[req_or_cap_name].properties
                 nested_property_name_or_index = self.nested_property_name_or_index[1:]
+            # First argument refers to a capability template?
             elif hasattr(modelable_entity, 'capability_templates') \
                 and modelable_entity.capability_templates \
                 and (req_or_cap_name in modelable_entity.capability_templates):
-                # First argument refers to a capability
                 properties = modelable_entity.capability_templates[req_or_cap_name].properties
                 nested_property_name_or_index = self.nested_property_name_or_index[1:]
             else:
@@ -640,7 +644,7 @@ def get_target(container_holder, name, locator):
 
 def get_modelable_entity_parameter(modelable_entity, parameters, nested_parameter_name_or_index):
     if not parameters:
-        return False, True, None
+        return Evaluation(None, True)
 
     found = True
     final = True

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/interfaces.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/interfaces.py
@@ -400,13 +400,15 @@ def merge_raw_operation_definitions(context, raw_operations, our_operations, int
 def merge_interface_definition(context, interface, our_source, presentation, type_name):
     if hasattr(our_source, 'type'):
         # Check if we changed the interface type
-        input_type1 = interface.type
-        input_type2 = our_source.type
-        if (input_type1 is not None) and (input_type2 is not None) and (input_type1 != input_type2):
+        type1 = interface._get_type(context)
+        type2 = our_source._get_type(context)
+
+        if (type2 is not None) and not type1._is_descendant(context, type2):
             context.validation.report(
-                'interface definition "%s" changes type from "%s" to "%s" in "%s"'
-                % (interface._name, input_type1, input_type2, presentation._fullname),
-                locator=input_type2._locator, level=Issue.BETWEEN_TYPES)
+                'interface definition type "{0}" is not a descendant of overridden '
+                'interface definition type "{1}"' \
+                .format(type1._name, type2._name),
+                locator=our_source._locator, level=Issue.BETWEEN_TYPES)
 
     # Add/merge inputs
     our_interface_inputs = our_source._get_inputs(context) \

--- a/extensions/aria_extension_tosca/simple_v1_0/presentation/types.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/presentation/types.py
@@ -18,7 +18,8 @@ def convert_name_to_full_type_name(context, name, types_dict): # pylint: disable
     """
     Converts a type name to its full type name, or else returns it unchanged.
 
-    Works by checking for ``shorthand_name`` in the types' ``_extensions`` field. See also
+    Works by checking for ``shorthand_name`` and ``type_qualified_name`` in the types'
+    ``_extensions`` field. See also
     :class:`aria_extension_tosca.v1_0.presentation.extensible.ExtensiblePresentation`.
 
     Can be used as the conversion function argument in ``type_validator`` and
@@ -36,9 +37,10 @@ def convert_name_to_full_type_name(context, name, types_dict): # pylint: disable
 
 def get_type_by_name(context, name, *types_dict_names):
     """
-    Gets a type either by its full name or its shorthand name or typequalified name.
+    Gets a type either by its full name or its shorthand name or type-qualified name.
 
-    Works by checking for ``shorthand_name`` in the types' ``_extensions`` field. See also
+    Works by checking for ``shorthand_name`` and ``type_qualified_name`` in the types'
+    ``_extensions`` field. See also
     :class:`~aria_extension_tosca.v1_0.presentation.extensible.ExtensiblePresentation`.
 
     The arguments from the third onwards are used to locate a nested field under

--- a/test_ssh.py
+++ b/test_ssh.py
@@ -1,0 +1,528 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import json
+import logging
+import os
+
+import pytest
+
+import fabric.api
+from fabric.contrib import files
+from fabric import context_managers
+
+from aria.modeling import models
+from aria.orchestrator import events
+from aria.orchestrator import workflow
+from aria.orchestrator.workflows import api
+from aria.orchestrator.workflows.executor import process
+from aria.orchestrator.workflows.core import engine, graph_compiler
+from aria.orchestrator.workflows.exceptions import ExecutorException
+from aria.orchestrator.exceptions import TaskAbortException, TaskRetryException
+from aria.orchestrator.execution_plugin import operations
+from aria.orchestrator.execution_plugin import constants
+from aria.orchestrator.execution_plugin.exceptions import ProcessException, TaskException
+from aria.orchestrator.execution_plugin.ssh import operations as ssh_operations
+
+from tests import mock, storage, resources
+from tests.orchestrator.workflows.helpers import events_collector
+
+_CUSTOM_BASE_DIR = '/tmp/new-aria-ctx'
+
+import tests
+KEY_FILENAME = os.path.join(tests.ROOT_DIR, 'tests/resources/keys/test')
+
+_FABRIC_ENV = {
+    'disable_known_hosts': True,
+    'user': 'test',
+    'key_filename': KEY_FILENAME
+}
+
+
+import mockssh
+@pytest.fixture(scope='session')
+def server():
+    with mockssh.Server({'test': KEY_FILENAME}) as s:
+        yield s
+
+
+#@pytest.mark.skipif(not os.environ.get('TRAVIS'), reason='actual ssh server required')
+class TestWithActualSSHServer(object):
+
+    def test_run_script_basic(self):
+        expected_attribute_value = 'some_value'
+        props = self._execute(env={'test_value': expected_attribute_value})
+        assert props['test_value'].value == expected_attribute_value
+
+    @pytest.mark.skip(reason='sudo privileges are required')
+    def test_run_script_as_sudo(self):
+        self._execute(use_sudo=True)
+        with self._ssh_env():
+            assert files.exists('/opt/test_dir')
+            fabric.api.sudo('rm -rf /opt/test_dir')
+
+    def test_run_script_default_base_dir(self):
+        props = self._execute()
+        assert props['work_dir'].value == '{0}/work'.format(constants.DEFAULT_BASE_DIR)
+
+    @pytest.mark.skip(reason='Re-enable once output from process executor can be captured')
+    @pytest.mark.parametrize('hide_groups', [[], ['everything']])
+    def test_run_script_with_hide(self, hide_groups):
+        self._execute(hide_output=hide_groups)
+        output = 'TODO'
+        expected_log_message = ('[localhost] run: source {0}/scripts/'
+                                .format(constants.DEFAULT_BASE_DIR))
+        if hide_groups:
+            assert expected_log_message not in output
+        else:
+            assert expected_log_message in output
+
+    def test_run_script_process_config(self):
+        expected_env_value = 'test_value_env'
+        expected_arg1_value = 'test_value_arg1'
+        expected_arg2_value = 'test_value_arg2'
+        expected_cwd = '/tmp'
+        expected_base_dir = _CUSTOM_BASE_DIR
+        props = self._execute(
+            env={'test_value_env': expected_env_value},
+            process={
+                'args': [expected_arg1_value, expected_arg2_value],
+                'cwd': expected_cwd,
+                'base_dir': expected_base_dir
+            })
+        assert props['env_value'].value == expected_env_value
+        assert len(props['bash_version'].value) > 0
+        assert props['arg1_value'].value == expected_arg1_value
+        assert props['arg2_value'].value == expected_arg2_value
+        assert props['cwd'].value == expected_cwd
+        assert props['ctx_path'].value == '{0}/ctx'.format(expected_base_dir)
+
+    def test_run_script_command_prefix(self):
+        props = self._execute(process={'command_prefix': 'bash -i'})
+        assert 'i' in props['dollar_dash'].value
+
+    def test_run_script_reuse_existing_ctx(self):
+        expected_test_value_1 = 'test_value_1'
+        expected_test_value_2 = 'test_value_2'
+        props = self._execute(
+            test_operations=['{0}_1'.format(self.test_name),
+                             '{0}_2'.format(self.test_name)],
+            env={'test_value1': expected_test_value_1,
+                 'test_value2': expected_test_value_2})
+        assert props['test_value1'].value == expected_test_value_1
+        assert props['test_value2'].value == expected_test_value_2
+
+    def test_run_script_download_resource_plain(self, tmpdir):
+        resource = tmpdir.join('resource')
+        resource.write('content')
+        self._upload(str(resource), 'test_resource')
+        props = self._execute()
+        assert props['test_value'].value == 'content'
+
+    def test_run_script_download_resource_and_render(self, tmpdir):
+        resource = tmpdir.join('resource')
+        resource.write('{{ctx.service.name}}')
+        self._upload(str(resource), 'test_resource')
+        props = self._execute()
+        assert props['test_value'].value == self._workflow_context.service.name
+
+    @pytest.mark.parametrize('value', ['string-value', [1, 2, 3], {'key': 'value'}])
+    def test_run_script_inputs_as_env_variables_no_override(self, value):
+        props = self._execute(custom_input=value)
+        return_value = props['test_value'].value
+        expected = return_value if isinstance(value, basestring) else json.loads(return_value)
+        assert value == expected
+
+    @pytest.mark.parametrize('value', ['string-value', [1, 2, 3], {'key': 'value'}])
+    def test_run_script_inputs_as_env_variables_process_env_override(self, value):
+        props = self._execute(custom_input='custom-input-value',
+                              env={'custom_env_var': value})
+        return_value = props['test_value'].value
+        expected = return_value if isinstance(value, basestring) else json.loads(return_value)
+        assert value == expected
+
+    def test_run_script_error_in_script(self):
+        exception = self._execute_and_get_task_exception()
+        assert isinstance(exception, TaskException)
+
+    def test_run_script_abort_immediate(self):
+        exception = self._execute_and_get_task_exception()
+        assert isinstance(exception, TaskAbortException)
+        assert exception.message == 'abort-message'
+
+    def test_run_script_retry(self):
+        exception = self._execute_and_get_task_exception()
+        assert isinstance(exception, TaskRetryException)
+        assert exception.message == 'retry-message'
+
+    def test_run_script_abort_error_ignored_by_script(self):
+        exception = self._execute_and_get_task_exception()
+        assert isinstance(exception, TaskAbortException)
+        assert exception.message == 'abort-message'
+
+    def test_run_commands(self):
+        temp_file_path = '/tmp/very_temporary_file'
+        with self._ssh_env():
+            if files.exists(temp_file_path):
+                fabric.api.run('rm {0}'.format(temp_file_path))
+        self._execute(commands=['touch {0}'.format(temp_file_path)])
+        with self._ssh_env():
+            assert files.exists(temp_file_path)
+            fabric.api.run('rm {0}'.format(temp_file_path))
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, request, workflow_context, executor, capfd, server):
+        print 'HI!!!!!!!!!!', server.port
+        self._workflow_context = workflow_context
+        self._executor = executor
+        self._capfd = capfd
+        self.test_name = request.node.originalname or request.node.name
+        with self._ssh_env(server):
+            for directory in [constants.DEFAULT_BASE_DIR, _CUSTOM_BASE_DIR]:
+                if files.exists(directory):
+                    fabric.api.run('rm -rf {0}'.format(directory))
+
+    @contextlib.contextmanager
+    def _ssh_env(self, server):
+        with self._capfd.disabled():
+            with context_managers.settings(fabric.api.hide('everything'),
+                                           host_string='localhost:{0}'.format(server.port),
+                                           **_FABRIC_ENV):
+                yield
+
+    def _execute(self,
+                 env=None,
+                 use_sudo=False,
+                 hide_output=None,
+                 process=None,
+                 custom_input='',
+                 test_operations=None,
+                 commands=None):
+        process = process or {}
+        if env:
+            process.setdefault('env', {}).update(env)
+
+        test_operations = test_operations or [self.test_name]
+
+        local_script_path = os.path.join(resources.DIR, 'scripts', 'test_ssh.sh')
+        script_path = os.path.basename(local_script_path)
+        self._upload(local_script_path, script_path)
+
+        if commands:
+            operation = operations.run_commands_with_ssh
+        else:
+            operation = operations.run_script_with_ssh
+
+        node = self._workflow_context.model.node.get_by_name(mock.models.DEPENDENCY_NODE_NAME)
+        arguments = {
+            'script_path': script_path,
+            'fabric_env': _FABRIC_ENV,
+            'process': process,
+            'use_sudo': use_sudo,
+            'custom_env_var': custom_input,
+            'test_operation': '',
+        }
+        if hide_output:
+            arguments['hide_output'] = hide_output
+        if commands:
+            arguments['commands'] = commands
+        interface = mock.models.create_interface(
+            node.service,
+            'test',
+            'op',
+            operation_kwargs=dict(
+                function='{0}.{1}'.format(
+                    operations.__name__,
+                    operation.__name__),
+                arguments=arguments)
+        )
+        node.interfaces[interface.name] = interface
+
+        @workflow
+        def mock_workflow(ctx, graph):
+            ops = []
+            for test_operation in test_operations:
+                op_arguments = arguments.copy()
+                op_arguments['test_operation'] = test_operation
+                ops.append(api.task.OperationTask(
+                    node,
+                    interface_name='test',
+                    operation_name='op',
+                    arguments=op_arguments))
+
+            graph.sequence(*ops)
+            return graph
+        tasks_graph = mock_workflow(ctx=self._workflow_context)  # pylint: disable=no-value-for-parameter
+        graph_compiler.GraphCompiler(
+            self._workflow_context, self._executor.__class__).compile(tasks_graph)
+        eng = engine.Engine({self._executor.__class__: self._executor})
+        eng.execute(self._workflow_context)
+        return self._workflow_context.model.node.get_by_name(
+            mock.models.DEPENDENCY_NODE_NAME).attributes
+
+    def _execute_and_get_task_exception(self, *args, **kwargs):
+        signal = events.on_failure_task_signal
+        with events_collector(signal) as collected:
+            with pytest.raises(ExecutorException):
+                self._execute(*args, **kwargs)
+        return collected[signal][0]['kwargs']['exception']
+
+    def _upload(self, source, path):
+        self._workflow_context.resource.service.upload(
+            entry_id=str(self._workflow_context.service.id),
+            source=source,
+            path=path)
+
+    @pytest.fixture
+    def executor(self):
+        result = process.ProcessExecutor()
+        try:
+            yield result
+        finally:
+            result.close()
+
+    @pytest.fixture
+    def workflow_context(self, tmpdir):
+        workflow_context = mock.context.simple(str(tmpdir))
+        workflow_context.states = []
+        workflow_context.exception = None
+        yield workflow_context
+        storage.release_sqlite_storage(workflow_context.model)
+
+
+class TestFabricEnvHideGroupsAndRunCommands(object):
+
+    def test_fabric_env_default_override(self):
+        # first sanity for no override
+        self._run()
+        assert self.mock.settings_merged['timeout'] == constants.FABRIC_ENV_DEFAULTS['timeout']
+        # now override
+        invocation_fabric_env = self.default_fabric_env.copy()
+        timeout = 1000000
+        invocation_fabric_env['timeout'] = timeout
+        self._run(fabric_env=invocation_fabric_env)
+        assert self.mock.settings_merged['timeout'] == timeout
+
+    def test_implicit_host_string(self, mocker):
+        expected_host_address = '1.1.1.1'
+        mocker.patch.object(self._Ctx.task.actor, 'host')
+        mocker.patch.object(self._Ctx.task.actor.host, 'host_address', expected_host_address)
+        fabric_env = self.default_fabric_env.copy()
+        del fabric_env['host_string']
+        self._run(fabric_env=fabric_env)
+        assert self.mock.settings_merged['host_string'] == expected_host_address
+
+    def test_explicit_host_string(self):
+        fabric_env = self.default_fabric_env.copy()
+        host_string = 'explicit_host_string'
+        fabric_env['host_string'] = host_string
+        self._run(fabric_env=fabric_env)
+        assert self.mock.settings_merged['host_string'] == host_string
+
+    def test_override_warn_only(self):
+        fabric_env = self.default_fabric_env.copy()
+        self._run(fabric_env=fabric_env)
+        assert self.mock.settings_merged['warn_only'] is True
+        fabric_env = self.default_fabric_env.copy()
+        fabric_env['warn_only'] = False
+        self._run(fabric_env=fabric_env)
+        assert self.mock.settings_merged['warn_only'] is False
+
+    def test_missing_host_string(self):
+        with pytest.raises(TaskAbortException) as exc_ctx:
+            fabric_env = self.default_fabric_env.copy()
+            del fabric_env['host_string']
+            self._run(fabric_env=fabric_env)
+        assert '`host_string` not supplied' in str(exc_ctx.value)
+
+    def test_missing_user(self):
+        with pytest.raises(TaskAbortException) as exc_ctx:
+            fabric_env = self.default_fabric_env.copy()
+            del fabric_env['user']
+            self._run(fabric_env=fabric_env)
+        assert '`user` not supplied' in str(exc_ctx.value)
+
+    def test_missing_key_or_password(self):
+        with pytest.raises(TaskAbortException) as exc_ctx:
+            fabric_env = self.default_fabric_env.copy()
+            del fabric_env['key_filename']
+            self._run(fabric_env=fabric_env)
+        assert 'Access credentials not supplied' in str(exc_ctx.value)
+
+    def test_hide_in_settings_and_non_viable_groups(self):
+        groups = ('running', 'stdout')
+        self._run(hide_output=groups)
+        assert set(self.mock.settings_merged['hide_output']) == set(groups)
+        with pytest.raises(TaskAbortException) as exc_ctx:
+            self._run(hide_output=('running', 'bla'))
+        assert '`hide_output` must be a subset of' in str(exc_ctx.value)
+
+    def test_run_commands(self):
+        def test(use_sudo):
+            commands = ['command1', 'command2']
+            self._run(
+                commands=commands,
+                use_sudo=use_sudo)
+            assert all(item in self.mock.settings_merged.items() for
+                       item in self.default_fabric_env.items())
+            assert self.mock.settings_merged['warn_only'] is True
+            assert self.mock.settings_merged['use_sudo'] == use_sudo
+            assert self.mock.commands == commands
+            self.mock.settings_merged = {}
+            self.mock.commands = []
+        test(use_sudo=False)
+        test(use_sudo=True)
+
+    def test_failed_command(self):
+        with pytest.raises(ProcessException) as exc_ctx:
+            self._run(commands=['fail'])
+        exception = exc_ctx.value
+        assert exception.stdout == self.MockCommandResult.stdout
+        assert exception.stderr == self.MockCommandResult.stderr
+        assert exception.command == self.MockCommandResult.command
+        assert exception.exit_code == self.MockCommandResult.return_code
+
+    class MockCommandResult(object):
+        stdout = 'mock_stdout'
+        stderr = 'mock_stderr'
+        command = 'mock_command'
+        return_code = 1
+
+        def __init__(self, failed):
+            self.failed = failed
+
+    class MockFabricApi(object):
+
+        def __init__(self):
+            self.commands = []
+            self.settings_merged = {}
+
+        @contextlib.contextmanager
+        def settings(self, *args, **kwargs):
+            self.settings_merged.update(kwargs)
+            if args:
+                groups = args[0]
+                self.settings_merged.update({'hide_output': groups})
+            yield
+
+        def run(self, command):
+            self.commands.append(command)
+            self.settings_merged['use_sudo'] = False
+            return TestFabricEnvHideGroupsAndRunCommands.MockCommandResult(command == 'fail')
+
+        def sudo(self, command):
+            self.commands.append(command)
+            self.settings_merged['use_sudo'] = True
+            return TestFabricEnvHideGroupsAndRunCommands.MockCommandResult(command == 'fail')
+
+        def hide(self, *groups):
+            return groups
+
+        def exists(self, *args, **kwargs):
+            raise RuntimeError
+
+    class _Ctx(object):
+        INSTRUMENTATION_FIELDS = ()
+
+        class Task(object):
+            @staticmethod
+            def abort(message=None):
+                models.Task.abort(message)
+            actor = None
+
+        class Actor(object):
+            host = None
+
+        class Model(object):
+            @contextlib.contextmanager
+            def instrument(self, *args, **kwargs):
+                yield
+        task = Task
+        task.actor = Actor
+        model = Model()
+        logger = logging.getLogger()
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _mock_self_logging(*args, **kwargs):
+        yield
+    _Ctx.logging_handlers = _mock_self_logging
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, mocker):
+        self.default_fabric_env = {
+            'host_string': 'test',
+            'user': 'test',
+            'key_filename': 'test',
+        }
+        self.mock = self.MockFabricApi()
+        mocker.patch('fabric.api', self.mock)
+
+    def _run(self,
+             commands=(),
+             fabric_env=None,
+             process=None,
+             use_sudo=False,
+             hide_output=None):
+        operations.run_commands_with_ssh(
+            ctx=self._Ctx,
+            commands=commands,
+            process=process,
+            fabric_env=fabric_env or self.default_fabric_env,
+            use_sudo=use_sudo,
+            hide_output=hide_output)
+
+
+class TestUtilityFunctions(object):
+
+    def test_paths(self):
+        base_dir = '/path'
+        local_script_path = '/local/script/path.py'
+        paths = ssh_operations._Paths(base_dir=base_dir,
+                                      local_script_path=local_script_path)
+        assert paths.local_script_path == local_script_path
+        assert paths.remote_ctx_dir == base_dir
+        assert paths.base_script_path == 'path.py'
+        assert paths.remote_ctx_path == '/path/ctx'
+        assert paths.remote_scripts_dir == '/path/scripts'
+        assert paths.remote_work_dir == '/path/work'
+        assert paths.remote_env_script_path.startswith('/path/scripts/env-path.py-')
+        assert paths.remote_script_path.startswith('/path/scripts/path.py-')
+
+    def test_write_environment_script_file(self):
+        base_dir = '/path'
+        local_script_path = '/local/script/path.py'
+        paths = ssh_operations._Paths(base_dir=base_dir,
+                                      local_script_path=local_script_path)
+        env = {'one': "'1'"}
+        local_socket_url = 'local_socket_url'
+        remote_socket_url = 'remote_socket_url'
+        env_script_lines = set([l for l in ssh_operations._write_environment_script_file(
+            process={'env': env},
+            paths=paths,
+            local_socket_url=local_socket_url,
+            remote_socket_url=remote_socket_url
+        ).getvalue().split('\n') if l])
+        expected_env_script_lines = set([
+            'export PATH=/path:$PATH',
+            'export PYTHONPATH=/path:$PYTHONPATH',
+            'chmod +x /path/ctx',
+            'chmod +x {0}'.format(paths.remote_script_path),
+            'export CTX_SOCKET_URL={0}'.format(remote_socket_url),
+            'export LOCAL_CTX_SOCKET_URL={0}'.format(local_socket_url),
+            'export one=\'1\''
+        ])
+        assert env_script_lines == expected_env_script_lines

--- a/tests/end2end/test_hello_world.py
+++ b/tests/end2end/test_hello_world.py
@@ -20,7 +20,7 @@ from .. import helpers
 
 
 def test_hello_world(testenv):
-    hello_world_template_uri = helpers.get_example_uri('hello-world', 'helloworld.yaml')
+    hello_world_template_uri = helpers.get_example_uri('hello-world', 'hello-world.yaml')
     service_name = testenv.install_service(hello_world_template_uri)
 
     try:

--- a/tests/orchestrator/execution_plugin/test_ssh.py
+++ b/tests/orchestrator/execution_plugin/test_ssh.py
@@ -29,24 +29,31 @@ from aria.orchestrator import events
 from aria.orchestrator import workflow
 from aria.orchestrator.workflows import api
 from aria.orchestrator.workflows.executor import process
-from aria.orchestrator.workflows.core import engine, graph_compiler
+from aria.orchestrator.workflows.core import (engine, graph_compiler)
 from aria.orchestrator.workflows.exceptions import ExecutorException
-from aria.orchestrator.exceptions import TaskAbortException, TaskRetryException
+from aria.orchestrator.exceptions import (TaskAbortException, TaskRetryException)
 from aria.orchestrator.execution_plugin import operations
 from aria.orchestrator.execution_plugin import constants
-from aria.orchestrator.execution_plugin.exceptions import ProcessException, TaskException
+from aria.orchestrator.execution_plugin.exceptions import (ProcessException, TaskException)
 from aria.orchestrator.execution_plugin.ssh import operations as ssh_operations
 
 from tests import mock, storage, resources
 from tests.orchestrator.workflows.helpers import events_collector
+
 
 _CUSTOM_BASE_DIR = '/tmp/new-aria-ctx'
 
 _FABRIC_ENV = {
     'host_string': 'localhost',
     'user': 'travis',
-    'password': 'travis'
+    # 'password': 'travis',
+    'key_filename': '/home/travis/.ssh/id_rsa'
 }
+
+
+# To help debug in case of connection failures
+logging.getLogger('paramiko.transport').addHandler(logging.StreamHandler())
+logging.getLogger('paramiko.transport').setLevel(logging.DEBUG)
 
 
 @pytest.mark.skipif(not os.environ.get('TRAVIS'), reason='actual ssh server required')

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/node-cellar.yaml
@@ -89,7 +89,7 @@ topology_template:
       value: *DEFAULT_OPENSTACK_CREDENTIAL
 
   node_templates:
-  
+
     # Application
 
     node_cellar:
@@ -135,7 +135,7 @@ topology_template:
           properties:
             protocol: udp
             url_path: /nodecellar
-    
+
     node_cellar_database:
       description: >-
         Node Cellar MongoDB database.
@@ -151,7 +151,7 @@ topology_template:
           repository: node_cellar
 
     # Server software
-    
+
     nodejs:
       description: >-
         Node.js instance.
@@ -202,7 +202,7 @@ topology_template:
     loadbalancer:
       type: nginx.LoadBalancer
       properties:
-        algorithm: round-robin   
+        algorithm: round-robin
 
     # Hosts
 
@@ -273,7 +273,7 @@ topology_template:
           create: create_data_volume.sh
 
   groups:
-  
+
     node_cellar_group:
       type: openstack.Secured
       members:
@@ -286,7 +286,7 @@ topology_template:
             openstack_credential: { get_input: openstack_credential }
 
   policies:
-  
+
     app_scaling:
       type: aria.Scaling
       properties:
@@ -295,7 +295,7 @@ topology_template:
       targets:
         - node_cellar
         - nodejs
-  
+
     host_scaling:
       type: openstack.Scaling
       properties:
@@ -304,7 +304,7 @@ topology_template:
         default_instances: 2
       targets: # node templates or groups
         - node_cellar_group
-    
+
     juju:
       description: >-
         Juju plugin executes charms.
@@ -345,7 +345,7 @@ policy_types:
     description: >-
       Workflow to put all nodes in/out of maintenance mode. For web servers, this will show a "this
       site is under maintenance and we'll be back soon" web page. Database nodes will then close all
-      client connections cleanly and shut down services. 
+      client connections cleanly and shut down services.
     derived_from: aria.Workflow
     properties:
       implementation:

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/mongodb.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/mongodb.yaml
@@ -44,7 +44,7 @@ node_types:
   mongodb.Database:
     description: >-
       MongoDB database.
-      
+
       Supports importing database data if a mongodb.DatabaseDump is provided.
     derived_from: tosca.nodes.Database
     interfaces:

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/nodejs.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/nodejs.yaml
@@ -30,7 +30,7 @@ node_types:
         file: https://nodejs.org/dist/v4.4.7/node-v4.4.7-linux-x64.tar.xz
         deploy_path: /opt/nodejs
     capabilities:
-      data_endpoint: # @override 
+      data_endpoint: # @override
         type: tosca.capabilities.Endpoint
         properties:
           port:

--- a/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/openstack.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/node-cellar/types/openstack.yaml
@@ -31,7 +31,7 @@ node_types:
 
       You may assign an image_id or attach an openstack.Image artifact (the artifact
       will take precedence).
-    
+
       You may assign either flavor_id or flavor_name (flavor_id will take precedence).
       If neither are assigned, flavor_name has a default value.
     derived_from: tosca.nodes.Compute
@@ -87,7 +87,7 @@ node_types:
   openstack.Volume:
     description: >-
       OpenStack volume.
-      
+
       See: http://developer.openstack.org/api-ref-blockstorage-v2.html
     derived_from: tosca.nodes.BlockStorage
     properties:

--- a/tests/resources/service-templates/tosca-simple-1.0/types/shorthand-1/shorthand-1.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/types/shorthand-1/shorthand-1.yaml
@@ -6,17 +6,17 @@ description: >-
 topology_template:
 
   node_templates:
-  
+
     my_server:
       type: Compute
       requirements:
         - local_storage:
-            node: my_block_storage           
+            node: my_block_storage
             relationship:
               type: AttachesTo
               properties:
                 location: /path1/path2
-  
+
     my_block_storage:
       type: BlockStorage
       properties:

--- a/tests/resources/service-templates/tosca-simple-1.0/types/typequalified-1/typequalified-1.yaml
+++ b/tests/resources/service-templates/tosca-simple-1.0/types/typequalified-1/typequalified-1.yaml
@@ -6,17 +6,17 @@ description: >-
 topology_template:
 
   node_templates:
-  
+
     my_server:
       type: tosca:Compute
       requirements:
         - local_storage:
-            node: my_block_storage           
+            node: my_block_storage
             relationship:
               type: AttachesTo
               properties:
                 location: /path1/path2
-  
+
     my_block_storage:
       type: tosca:BlockStorage
       properties:

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@
 [tox]
 envlist=py27,py26,py27e2e,py26e2e,pywin,py27ssh,pylint_code,pylint_tests,docs
 processes={env:PYTEST_PROCESSES:auto}
+py26={env:PY26:python2.6}
 
 [testenv]
 whitelist_externals=
@@ -28,11 +29,11 @@ deps=
   --requirement
     tests/requirements.txt
 basepython=
-  py26: python2.6
+  py26: {[tox]py26}
   py27: python2.7
-  py26e2e: python2.6
+  py26e2e: {[tox]py26}
   py27e2e: python2.7
-  py26ssh: python2.6
+  py26ssh: {[tox]py26}
   py27ssh: python2.7
   pywin: {env:PYTHON:}\python.exe
   pylint_code: python2.7


### PR DESCRIPTION
Related fixes included in this commit:

* Allows capabilities, interfaces, and properties to override parent
definition types only if the new type is a descendant of the overridden
type
* Fix bugs in model instrumentation (to allow ctx access to capability
properties and complex values)
* Fix to get_property intrinsic function
* Fix the "required" field for parameters (it wasn't working)
* Don't let scalar values be negative
* Doc fixes related to ARIA-277