### PR TITLE
ARIA-353 Add node template directives

### DIFF
--- a/aria/modeling/service_template.py
+++ b/aria/modeling/service_template.py
@@ -457,6 +457,12 @@ class NodeTemplateBase(TemplateModelMixin):
     :type: :obj:`basestring`
     """)
 
+    directives = Column(PickleType, doc="""
+    Directives that apply to this node template.
+
+    :type: [:obj:`basestring`]
+    """)
+
     default_instances = Column(Integer, default=1, doc="""
     Default number nodes that will appear in the service.
 

--- a/aria/parser/presentation/fields.py
+++ b/aria/parser/presentation/fields.py
@@ -437,7 +437,7 @@ class Field(object):
             raw = deepcopy_with_locators(default_raw)
             merge(raw, presentation._raw)
 
-        # Handle unknown fields
+        # Handle unknown fields (only dict can have unknown fields, lists can't have them)
 
         if self.field_variant == 'primitive_dict_unknown_fields':
             return self._get_primitive_dict_unknown_fields(presentation, raw, context)
@@ -473,7 +473,8 @@ class Field(object):
 
         # Handle get according to variant
 
-        getter = getattr(self, '_get_%s' % self.field_variant, None)
+        getter = getattr(self, '_get_{field_variant}'.format(field_variant=self.field_variant),
+                         None)
 
         if getter is None:
             locator = self.get_locator(raw)

--- a/extensions/aria_extension_tosca/simple_v1_0/modeling/__init__.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/modeling/__init__.py
@@ -163,11 +163,13 @@ def create_metadata_models(context, service_template, metadata):
 def create_node_template_model(context, service_template, node_template):
     node_type = node_template._get_type(context)
     node_type = service_template.node_types.get_descendant(node_type._name)
-    model = NodeTemplate(name=node_template._name,
-                         type=node_type)
+    model = NodeTemplate(name=node_template._name, type=node_type)
 
     if node_template.description:
         model.description = node_template.description.value
+
+    if node_template.directives:
+        model.directives = node_template.directives
 
     model.properties.update(create_property_models_from_values(
         template_properties=node_template._get_property_values(context)))


### PR DESCRIPTION
The directives field already existed in the presentation level, but it
needed to be added to the node template model.