### PR TITLE
ARIA-118 plugin.yaml importing

### DIFF
--- a/extensions/aria_extension_tosca/simple_v1_0/presenter.py
+++ b/extensions/aria_extension_tosca/simple_v1_0/presenter.py
@@ -38,6 +38,8 @@ class ToscaSimplePresenter1_0(Presenter):                                       
     SIMPLE_PROFILE_LOCATION = 'tosca-simple-1.0/tosca-simple-1.0.yaml'
     SPECIAL_IMPORTS = {
         'aria-1.0': 'aria-1.0/aria-1.0.yaml'}
+    PLUGIN_IMPORT_FILE = '/plugin.yaml'
+    PLUGIN_REPOSITORY = 'plugins'
 
     @property
     @cachedmethod
@@ -74,7 +76,12 @@ class ToscaSimplePresenter1_0(Presenter):                                       
             import_locations.append(self.SIMPLE_PROFILE_LOCATION)
         imports = self._get('service_template', 'imports')
         if imports:
-            import_locations += [self.SPECIAL_IMPORTS.get(i.file, i.file) for i in imports]
+            for i in imports:
+                if i.repository == self.PLUGIN_REPOSITORY:
+                    #Add plugin.yaml from plugin resource storage to import locations
+                    import_locations += [i.file + self.PLUGIN_IMPORT_FILE]
+                else:
+                    import_locations += [self.SPECIAL_IMPORTS.get(i.file, i.file)]
         return FrozenList(import_locations) if import_locations else EMPTY_READ_ONLY_LIST
 
     @cachedmethod

--- a/tests/extensions/aria_extension_tosca/simple_v1_0/test_imports.py
+++ b/tests/extensions/aria_extension_tosca/simple_v1_0/test_imports.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from tests.helpers import get_resource_uri
 from . import data
 from ....mechanisms.web_server import WebServer
 
@@ -37,6 +38,8 @@ node_types:
   MyNode:
     derived_from: UnknownType
 """
+
+PLUGIN_RESOURCES = "plugins"
 
 @pytest.fixture(scope='session')
 def repository():
@@ -146,6 +149,21 @@ topology_template:
       type: MyNode
 """, dict(repository=repository)).assert_success()
 
+#Plugin
+#Test case for importing plugin.yaml files via 'plugins' repository
+def test_import_plugin(parser):
+    plugin_dir = get_resource_uri(PLUGIN_RESOURCES)
+    parser.parse_literal("""
+tosca_definitions_version: tosca_simple_yaml_1_0
+imports:
+  - aria-1.0
+  - file: import-plugin-1.0.0
+    repository: plugins
+topology_template:
+  node_templates:
+    Network:
+      type: myapp.nodes.Network
+""", plugin_dir=plugin_dir).assert_success()
 
 # Namespace
 

--- a/tests/mechanisms/parsing/aria.py
+++ b/tests/mechanisms/parsing/aria.py
@@ -24,6 +24,7 @@ from aria.parser.consumption import (
     ServiceTemplate
 )
 from aria.utils.imports import import_fullname
+from aria.utils import collections
 
 from . import (Parser, Parsed)
 
@@ -32,6 +33,7 @@ class AriaParser(Parser):
     def _parse_literal(self, text, **kwargs):
         context = AriaParser.create_context(import_profile=kwargs.get('import_profile', False),
                                             adhoc_inputs=kwargs.get('adhoc_inputs', True),
+                                            plugin_dir=kwargs.get('plugin_dir', None),
                                             validate_normative=kwargs.get('validate_normative',
                                                                           False))
         context.presentation.location = LiteralLocation(text)
@@ -52,6 +54,7 @@ class AriaParser(Parser):
                        cache=True,
                        import_profile=None,
                        adhoc_inputs=None,
+                       plugin_dir=None,
                        validate_normative=None):
         context = ConsumptionContext()
         context.loading.loader_source = import_fullname(loader_source)()
@@ -66,6 +69,8 @@ class AriaParser(Parser):
             context.presentation.configuration['tosca.adhoc_inputs'] = adhoc_inputs
         if validate_normative is not None:
             context.presentation.configuration['validate_normative'] = validate_normative
+        if plugin_dir:
+            context.loading.prefixes = collections.StrictList([plugin_dir])
         context.presentation.print_exceptions = debug
         return context
 

--- a/tests/resources/plugins/import-plugin-1.0.0/plugin.yaml
+++ b/tests/resources/plugins/import-plugin-1.0.0/plugin.yaml
@@ -1,0 +1,16 @@
+tosca_definitions_version: tosca_simple_yaml_1_0
+
+
+topology_template:
+
+  policies:
+    import-plugin:
+      description: >-
+        plugin to test import of plugin.yaml.
+      type: aria.Plugin
+      properties:
+        version: 1.0.0
+
+node_types:
+
+  myapp.nodes.Network: {}


### PR DESCRIPTION
Import "plugin.yaml" present in plugin resource storage via 'plugins' repository.